### PR TITLE
add gnark tower inverses

### DIFF
--- a/src/bn254/g2.cairo
+++ b/src/bn254/g2.cairo
@@ -153,7 +153,7 @@ namespace g2 {
     func compute_doubling_slope_pure_cairo_towers{range_check_ptr}(pt: G2Point) -> E2 {
         alloc_locals;
         let two_y = e2.double(pt.y);
-        let A = e2.inv(two_y);
+        let A = e2.inverse(two_y);
         let x_sq = e2.square(pt.x);
         tempvar three = new BigInt3(3, 0, 0);
         let B = e2.mul_by_element(three, x_sq);

--- a/src/bn254/towers/e12.cairo
+++ b/src/bn254/towers/e12.cairo
@@ -115,6 +115,20 @@ namespace e12 {
 
     func inverse{range_check_ptr}(x: E12*) -> E12* {
         alloc_locals;
+        let t0 = e6.square(x.c0);
+        let t1 = e6.square(x.c1);
+        let tmp = e6.mul_by_non_residue(t1);
+        let t0 = e6.sub(t0, tmp);
+        let t1 = e6.inverse(t0);
+        let c0 = e6.mul(x.c0, t1);
+        let c1 = e6.mul(x.c1, t1);
+        let c1 = e6.neg(c1);
+        tempvar res = new E12(c0, c1);
+        return res;
+    }
+
+    func inverse_hint{range_check_ptr}(x: E12*) -> E12* {
+        alloc_locals;
         let (__fp__, _) = get_fp_and_pc();
         local inv0: BigInt3;
         local inv1: BigInt3;

--- a/src/bn254/towers/e2.cairo
+++ b/src/bn254/towers/e2.cairo
@@ -33,7 +33,20 @@ namespace e2 {
         return res;
     }
 
-    func inv{range_check_ptr}(x: E2*) -> E2* {
+    func inverse{range_check_ptr}(x: E2*) -> E2* {
+        alloc_locals;
+        let t0 = fq_bigint3.mul(x.a0, x.a0);
+        let t1 = fq_bigint3.mul(x.a1, x.a1);
+        let t0 = fq_bigint3.add(t0, t1);
+        let t1 = fq_bigint3.inv(t0);
+        let a0 = fq_bigint3.mul(x.a0, t1);
+        let a1 = fq_bigint3.mul(x.a1, t1);
+        let a1 = fq_bigint3.neg(a1);
+        tempvar res = new E2(a0, a1);
+        return res;
+    }
+
+    func inv_hint{range_check_ptr}(x: E2*) -> E2* {
         alloc_locals;
         let (__fp__, _) = get_fp_and_pc();
         local inverse0: BigInt3;
@@ -80,6 +93,7 @@ namespace e2 {
         assert check_is_zero = 1;
         return &inverse;
     }
+
     func add{range_check_ptr}(x: E2*, y: E2*) -> E2* {
         alloc_locals;
         let a0 = fq_bigint3.add(x.a0, y.a0);
@@ -96,12 +110,14 @@ namespace e2 {
         tempvar res = new E2(a0, a1);
         return res;
     }
+
     func neg{range_check_ptr}(x: E2*) -> E2* {
         alloc_locals;
         let zero_2 = e2.zero();
         let res = sub(zero_2, x);
         return res;
     }
+
     func sub{range_check_ptr}(x: E2*, y: E2*) -> E2* {
         alloc_locals;
         let a0 = fq_bigint3.sub(x.a0, y.a0);
@@ -109,6 +125,7 @@ namespace e2 {
         tempvar res = new E2(a0, a1);
         return res;
     }
+
     func mul_by_element{range_check_ptr}(n: BigInt3*, x: E2*) -> E2* {
         alloc_locals;
         let a0 = fq_bigint3.mul(x.a0, n);
@@ -116,6 +133,7 @@ namespace e2 {
         tempvar res = new E2(a0, a1);
         return res;
     }
+
     func mul{range_check_ptr}(x: E2*, y: E2*) -> E2* {
         alloc_locals;
 
@@ -135,6 +153,7 @@ namespace e2 {
         tempvar res = new E2(z_a0, z_a1);
         return res;
     }
+
     func square{range_check_ptr}(x: E2*) -> E2* {
         // z.A0 = (x.A0 + x.A1) * (x.A0 - x.A1)
         // z.A1 = 2 * x.A0 * x.A1
@@ -148,6 +167,7 @@ namespace e2 {
         tempvar res = new E2(a0, a1);
         return res;
     }
+
     func mul2{range_check_ptr}(x: E2*, y: E2*) -> E2* {
         alloc_locals;
 

--- a/src/bn254/towers/e6.cairo
+++ b/src/bn254/towers/e6.cairo
@@ -76,6 +76,59 @@ namespace e6 {
         return res;
     }
 
+    // Square sets z to the E6 product of x,x, returns z
+    func square{range_check_ptr}(x: E6*) -> E6* {
+        alloc_locals;
+        let c4 = e2.mul(x.b0, x.b1);
+        let c4 = e2.double(c4);
+        let c5 = e2.square(x.b2);
+        let c1 = e2.mul_by_non_residue(c5);
+        let c1 = e2.add(c1, c4);
+        let c2 = e2.sub(c4, c5);
+        let c3 = e2.square(x.b0);
+        let c4 = e2.sub(x.b0, x.b1);
+        let c4 = e2.add(c4, x.b2);
+        let c5 = e2.mul(x.b1, x.b2);
+        let c5 = e2.double(c5);
+        let c4 = e2.square(c4);
+        let c0 = e2.mul_by_non_residue(c5);
+        let c0 = e2.add(c0, c3);
+        let c2 = e2.add(c2, c4);
+        let c2 = e2.add(c2, c5);
+        let c2 = e2.sub(c2, c3);
+        tempvar res = new E6(c0, c1, c2);
+        return res;
+    }
+
+    // Invert E6 element
+    func inverse{range_check_ptr}(x: E6*) -> E6* {
+        alloc_locals;
+        let t0 = e2.square(x.b0);
+        let t1 = e2.square(x.b1);
+        let t2 = e2.square(x.b2);
+        let t3 = e2.mul(x.b0, x.b1);
+        let t4 = e2.mul(x.b0, x.b2);
+        let t5 = e2.mul(x.b1, x.b2);
+        let c0 = e2.mul_by_non_residue(t5);
+        let c0 = e2.neg(c0);
+        let c0 = e2.add(c0, t0);
+        let c1 = e2.mul_by_non_residue(t2);
+        let c1 = e2.sub(c1, t3);
+        let c2 = e2.sub(t1, t4);
+        let t6 = e2.mul(x.b0, c0);
+        let d1 = e2.mul(x.b2, c1);
+        let d2 = e2.mul(x.b1, c2);
+        let d1 = e2.add(d1, d2);
+        let d1 = e2.mul_by_non_residue(d1);
+        let t6 = e2.add(t6, d1);
+        let t6 = e2.inverse(t6);
+        let b0 = e2.mul(c0, t6);
+        let b1 = e2.mul(c1, t6);
+        let b2 = e2.mul(c2, t6);
+        tempvar res = new E6(b0, b1, b2);
+        return res;
+    }
+
     func mul_by_non_residue{range_check_ptr}(x: E6*) -> E6* {
         alloc_locals;
         let zB0 = x.b2;


### PR DESCRIPTION
Added pure Cairo tower inverse function based on gnark's implementation

# Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

inverse functions for e2 and e12 currently use hints

Issue Number: #47

# What is the new behavior?

Inverse function are in pure Cairo and related protostar tests pass

# Does this introduce a breaking change?

- [ ] Yes
- [X] No
