### PR TITLE
Feat:  Use pair_multi in precompile contract

### DIFF
--- a/contracts/cairo_bn254/bn254_precompiles.cairo
+++ b/contracts/cairo_bn254/bn254_precompiles.cairo
@@ -63,9 +63,9 @@ func ecMul{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
 // @return res The result of the pairing success as a boolean.
 @view
 func ecPairing{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    p_len: felt, p_arr: G1PointFull*, q_len: felt252, q_arr: G2PointFull*
+    n: felt, p_arr: G1PointFull*, q_arr: G2PointFull*
 ) -> (res: felt) {
-    let (res) = BN254Precompiles.ec_pairing(p_len, p_arr, q_len, q_arr, input);
+    let (res) = BN254Precompiles.ec_pairing(n, p_arr, q_arr);
     return (res=res);
 }
 

--- a/contracts/cairo_bn254/bn254_precompiles.cairo
+++ b/contracts/cairo_bn254/bn254_precompiles.cairo
@@ -10,8 +10,15 @@ from openzeppelin.upgrades.library import Proxy
 
 // Local dependencies.
 from src.bn254.g1 import G1PointFull
-from contracts.cairo_bn254.library import BN254Precompiles, PairingInput
+from src.bn254.g2 import G2PointFull
+from contracts.cairo_bn254.library import BN254Precompiles
 
+//
+// Initializer
+//
+
+// @notice Initialize the contract with the given parameters.
+//   This constructor uses a dedicated function initialize the proxy.
 @external
 func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
     let (owner) = get_caller_address();
@@ -19,6 +26,14 @@ func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
     return ();
 }
 
+//
+// Views
+//
+
+// @notice Add two G1 Points.
+// @param a The first G1 Point.
+// @param b The second G1 Point.
+// @return res The addition result.
 @view
 func ecAdd{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     a: G1PointFull, b: G1PointFull
@@ -27,6 +42,10 @@ func ecAdd{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     return (res=res);
 }
 
+// @notice Multiply a G1 Point by a scalar.
+// @param a The G1 Point.
+// @param s The scalar.
+// @return res The multiplication result.
 @view
 func ecMul{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     a: G1PointFull, s: BigInt3
@@ -36,11 +55,17 @@ func ecMul{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     return (res=res);
 }
 
+// @notice Computes the pairing of an array of (G1,G2) points.
+// @param p_len The length of G1 points array.
+// @param p_arr The G1 point array.
+// @param q_len The length of G2 points array.
+// @param q_len The G1 point array.
+// @return res The result of the pairing success as a boolean.
 @view
 func ecPairing{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    input_len: felt, input: PairingInput*
+    p_len: felt, p_arr: G1PointFull*, q_len: felt252, q_arr: G2PointFull*
 ) -> (res: felt) {
-    let (res) = BN254Precompiles.ec_pairing(input_len, input);
+    let (res) = BN254Precompiles.ec_pairing(p_len, p_arr, q_len, q_arr, input);
     return (res=res);
 }
 
@@ -63,6 +88,10 @@ func getImplementationHash{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range
 func getAdmin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (admin: felt) {
     return Proxy.get_admin();
 }
+
+//
+// Externals
+//
 
 // @notice Upgrade the contract to the new implementation.
 // @dev This function is only callable by the admin.

--- a/tests/protostar_tests/bn254/test_precompiles.cairo
+++ b/tests/protostar_tests/bn254/test_precompiles.cairo
@@ -64,9 +64,8 @@ func test_pair_two_inputs{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_
     assert q_arr[1] = pt_g2;
 
     let (res: felt) = BN254Precompiles.ec_pairing(
-        p_len=2,
+        n=2,
         p_arr=p_arr,
-        q_len=2,
         q_arr=q_arr,
     );
 

--- a/tests/protostar_tests/bn254/test_precompiles.cairo
+++ b/tests/protostar_tests/bn254/test_precompiles.cairo
@@ -13,7 +13,7 @@ from src.bn254.fq import BigInt3
 from src.bn254.g1 import G1Point, G1, g1, G1PointFull
 from src.bn254.g2 import G2Point, g2, get_g2_generator, get_n_g2_generator
 from src.bn254.towers.e12 import E12, e12
-from contracts.cairo_bn254.library import G2PointFull, E2Full, PairingInput, BN254Precompiles
+from contracts.cairo_bn254.library import G2PointFull, E2Full, BN254Precompiles
 
 @view
 func test_ec_add{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
@@ -56,10 +56,19 @@ func test_pair_two_inputs{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_
         x=E2Full(a0=[pt_g2_.x.a0], a1=[pt_g2_.x.a1]), y=E2Full(a0=[pt_g2_.y.a0], a1=[pt_g2_.y.a1])
     );
 
-    let (local input: PairingInput*) = alloc();
-    assert input[0] = PairingInput(p=minus_g1, q=pt_g2);
-    assert input[1] = PairingInput(p=pt_g1, q=pt_g2);
-    let (res: felt) = BN254Precompiles.ec_pairing(2, input);
+    let (local p_arr: G1PointFull*) = alloc();
+    let (local q_arr: G2PointFull*) = alloc();
+    assert p_arr[0] = minus_g1;
+    assert q_arr[0] = pt_g2;
+    assert p_arr[1] = pt_g1;
+    assert q_arr[1] = pt_g2;
+
+    let (res: felt) = BN254Precompiles.ec_pairing(
+        p_len=2,
+        p_arr=p_arr,
+        q_len=2,
+        q_arr=q_arr,
+    );
 
     assert 1 = res;
     return ();


### PR DESCRIPTION
Result of the test for pairings with two inputs.
```
[PASS] tests/protostar_tests/bn254/test_precompiles.cairo test_pair_two_inputs 
(time=153.21s, steps=1765612, memory_holes=7342)
range_check_builtin=112762
```
       