### PR TITLE
Refactored `from_json` methods of Groth16Proof and Groth16VerifyingKeys classes

### DIFF
--- a/hydra/garaga/starknet/groth16_contract_generator/parsing_utils.py
+++ b/hydra/garaga/starknet/groth16_contract_generator/parsing_utils.py
@@ -368,6 +368,8 @@ class Groth16Proof:
             if public_inputs_path is not None:
                 with Path(public_inputs_path).open("r") as f:
                     public_inputs = json.load(f)
+            else:
+                public_inputs = None
         except FileNotFoundError:
             raise FileNotFoundError(f"The file {public_inputs_path} was not found.")
         except json.JSONDecodeError:

--- a/hydra/garaga/starknet/groth16_contract_generator/parsing_utils.py
+++ b/hydra/garaga/starknet/groth16_contract_generator/parsing_utils.py
@@ -312,7 +312,9 @@ class Groth16Proof:
         ), f"All points must be on the same curve, got {self.a.curve_id}, {self.b.curve_id}, {self.c.curve_id}"
         self.curve_id = self.a.curve_id
 
-    def from_dict(data: dict, public_inputs: str) -> "Groth16Proof":
+    def from_dict(
+        data: dict, public_inputs: None | list | dict = None
+    ) -> "Groth16Proof":
         curve_id = try_guessing_curve_id_from_json(data)
         try:
             proof = find_item_from_key_patterns(data, ["proof"])


### PR DESCRIPTION
* added `from_dict` methods to both classes.
* decoupled the class instantiation from json parsing

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?
The current `from_json` methods in `Groth16Proof` and `Groth16VerifyingKey` classes are responsible for reading  json files containing the verifying key, proof and public inputs, and then process that content to produce an output. We wanted to be able to pass the content of the json files as python dictionaries without the need to read/write files on disk. 

This behavior limits our ability to process dynamic inputs. For example when trying to wrap Garaga with and API.

Issue Number: N/A

# What is the new behavior?
We created a method in both classes called `from_dict`, whose implementations are a verbatim copy of the `from_json` method without the json file parsing part. We rewrote the both `from_json` methods to read the json file and then pass the content to the newly created `from_dict`. This change is transparent to previous calls to the `from_json` method.

# Does this introduce a breaking change?
- [ ] Yes
- [x] No

# Other information