### PR TITLE
Simpler CLI command naming, minor docs inconsistencies and deploy_v1 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Currently, only Groth16 on BN254 and BLS12_381 is supported with automatic suppo
 4. Edit the generated smart contract to fit the needs of your dapp.
 
 5. Create an environment file `.secrets` following  the `.secrets.template` file in the root of this repository, containing the Starkner RPC url, your account address, and the private key.
-6. Run the `garaga declare-project` command in your terminal to declare the smart contract on Starknet and obtain its class hash. Note that this is an expensive operation.
-7. Run the `garaga deploy-project` command in your terminal using the class hash obtained in the previous step to get the contract address.
+6. Run the `garaga declare` command in your terminal to declare the smart contract on Starknet and obtain its class hash. Note that this is an expensive operation.
+7. Run the `garaga deploy` command in your terminal using the class hash obtained in the previous step to get the contract address.
 
 7. Run the `garaga verify-onchain` command in your terminal using the contract address, the verification key, the proof and the public inputs to verify the proof against the SNARK verifier contract.
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Currently, only Groth16 on BN254 and BLS12_381 is supported with automatic suppo
 4. Edit the generated smart contract to fit the needs of your dapp.
 
 5. Create an environment file `.secrets` following  the `.secrets.template` file in the root of this repository, containing the Starkner RPC url, your account address, and the private key.
-6. Run the `garaga declare` command in your terminal to declare the smart contract on Starknet and obtain its class hash. Note that this is an expensive operation.
-7. Run the `garaga deploy` command in your terminal using the class hash obtained in the previous step to get the contract address.
+6. Run the `garaga declare-project` command in your terminal to declare the smart contract on Starknet and obtain its class hash. Note that this is an expensive operation.
+7. Run the `garaga deploy-project` command in your terminal using the class hash obtained in the previous step to get the contract address.
 
 7. Run the `garaga verify-onchain` command in your terminal using the contract address, the verification key, the proof and the public inputs to verify the proof against the SNARK verifier contract.
 

--- a/docs/gitbook/deploy-your-snark-verifier-on-starknet/groth16/generate-and-deploy-your-verifier-contract.md
+++ b/docs/gitbook/deploy-your-snark-verifier-on-starknet/groth16/generate-and-deploy-your-verifier-contract.md
@@ -301,18 +301,18 @@ MAINNET_ACCOUNT_ADDRESS=0x4
 ```
 {% endcode %}
 
-Then, you can run the command `garaga declare-project`, which will build the contract and declare it to Starknet. If the class hash is already deployed, it will return it as well. Declaring the contract involves sending all its bytecode and it is quite an expensive operation. Make sure you dapp is properly tested before!
+Then, you can run the command `garaga declare`, which will build the contract and declare it to Starknet. If the class hash is already deployed, it will return it as well. Declaring the contract involves sending all its bytecode and it is quite an expensive operation. Make sure you dapp is properly tested before!
 
 ```bash
- Usage: garaga declare-project [OPTIONS]
+ Usage: garaga declaret [OPTIONS]
 
  Declare your smart contract to Starknet. Obtain its class hash and a explorer link.
 
 ╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ --project-path          DIRECTORY          Path to the Cairo project holding the Scarb.toml file to declare                         │
-│                                            [default: /home/felt/PycharmProjects/garaga-flow/my_project/]                            │
+│                                            [default: /home/felt/garaga-flow/my_project/]                            │
 │ --env-file              FILE               Path to the environment file                                                             │
-│                                            [default: /home/felt/PycharmProjects/garaga-flow/my_project/.secrets]                    │
+│                                            [default: /home/felt/garaga-flow/my_project/.secrets]                    │
 │ --network               [sepolia|mainnet]  Starknet network [default: sepolia]                                                      │
 │ --fee                   TEXT               Fee token type [eth, strk] [default: eth]                                                │
 │ --help          -h                         Show this message and exit.                                                              │
@@ -320,22 +320,22 @@ Then, you can run the command `garaga declare-project`, which will build the con
 ```
 
 ```bash
-garaga declare-project --project-path my_project/ --env-file .secrets --network sepolia --fee strk
+garaga declare --project-path my_project/ --env-file .secrets --network sepolia --fee strk
 ```
 
 This command will return the class hash, used in the next step.\
 \
-Finally, to deploy the contract, a use `garaga deploy-project` :
+Finally, to deploy the contract, a use `garaga deploy` :
 
 ```bash
- Usage: garaga deploy-project [OPTIONS]
+ Usage: garaga deploy [OPTIONS]
 
  Deploy an instance of a smart contract class hash to Starknet. Obtain its address, the available endpoints and a explorer link.
 
 ╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ *  --class-hash          TEXT               Contract class hash to deploy. Can be decimal or hex string [default: None] [required]  │
 │    --env-file            FILE               Path to the environment file containing rpc, address, private_key                       │
-│                                             [default: /home/felt/PycharmProjects/garaga-flow/my_project/.secrets]                   │
+│                                             [default: /home/felt/garaga-flow/my_project/.secrets]                   │
 │    --network             [sepolia|mainnet]  Starknet network [default: sepolia]                                                     │
 │    --fee                 TEXT               Fee token type [eth, strk] [default: strk]                                              │
 │    --help        -h                         Show this message and exit.                                                             │

--- a/docs/gitbook/deploy-your-snark-verifier-on-starknet/groth16/generate-and-deploy-your-verifier-contract.md
+++ b/docs/gitbook/deploy-your-snark-verifier-on-starknet/groth16/generate-and-deploy-your-verifier-contract.md
@@ -122,14 +122,14 @@ garaga
 Once your verifying key is ready, you can use the following command :&#x20;
 
 ```
-garaga gen --system groth16 --vk vk.json 
+garaga gen --system groth16 --vk vk.json
 ```
 
 You should see an output like this :
 
 ```bash
-(venv) :~/garaga-flow garaga gen --system groth16 --vk vk_bls.json 
-Please enter the name of your project. Press enter for default name. [my_project]:   
+(venv) :~/garaga-flow garaga gen --system groth16 --vk vk_bls.json
+Please enter the name of your project. Press enter for default name. [my_project]:
 Detected curve: CurveID.BLS12_381
 ⠧ Generating Smart Contract project for ProofSystem.Groth16 using vk_bls.json...
 Done!
@@ -304,10 +304,10 @@ MAINNET_ACCOUNT_ADDRESS=0x4
 Then, you can run the command `garaga declare-project`, which will build the contract and declare it to Starknet. If the class hash is already deployed, it will return it as well. Declaring the contract involves sending all its bytecode and it is quite an expensive operation. Make sure you dapp is properly tested before!
 
 ```bash
- Usage: garaga declare-project [OPTIONS]                                                                                               
-                                                                                                                                       
- Declare your smart contract to Starknet. Obtain its class hash and a explorer link.                                                   
-                                                                                                                                       
+ Usage: garaga declare-project [OPTIONS]
+
+ Declare your smart contract to Starknet. Obtain its class hash and a explorer link.
+
 ╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ --project-path          DIRECTORY          Path to the Cairo project holding the Scarb.toml file to declare                         │
 │                                            [default: /home/felt/PycharmProjects/garaga-flow/my_project/]                            │
@@ -320,7 +320,7 @@ Then, you can run the command `garaga declare-project`, which will build the con
 ```
 
 ```bash
-garaga declare-project --project-path my-project/ --env-file .secrets --network sepolia --fee strk
+garaga declare-project --project-path my_project/ --env-file .secrets --network sepolia --fee strk
 ```
 
 This command will return the class hash, used in the next step.\
@@ -328,10 +328,10 @@ This command will return the class hash, used in the next step.\
 Finally, to deploy the contract, a use `garaga deploy-project` :
 
 ```bash
- Usage: garaga deploy-project [OPTIONS]                                                                                                
-                                                                                                                                       
- Deploy an instance of a smart contract class hash to Starknet. Obtain its address, the available endpoints and a explorer link.       
-                                                                                                                                       
+ Usage: garaga deploy-project [OPTIONS]
+
+ Deploy an instance of a smart contract class hash to Starknet. Obtain its address, the available endpoints and a explorer link.
+
 ╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ *  --class-hash          TEXT               Contract class hash to deploy. Can be decimal or hex string [default: None] [required]  │
 │    --env-file            FILE               Path to the environment file containing rpc, address, private_key                       │

--- a/docs/gitbook/deploy-your-snark-verifier-on-starknet/groth16/generate-and-deploy-your-verifier-contract.md
+++ b/docs/gitbook/deploy-your-snark-verifier-on-starknet/groth16/generate-and-deploy-your-verifier-contract.md
@@ -304,7 +304,7 @@ MAINNET_ACCOUNT_ADDRESS=0x4
 Then, you can run the command `garaga declare`, which will build the contract and declare it to Starknet. If the class hash is already deployed, it will return it as well. Declaring the contract involves sending all its bytecode and it is quite an expensive operation. Make sure you dapp is properly tested before!
 
 ```bash
- Usage: garaga declaret [OPTIONS]
+ Usage: garaga declare [OPTIONS]
 
  Declare your smart contract to Starknet. Obtain its class hash and a explorer link.
 

--- a/docs/gitbook/deploy-your-snark-verifier-on-starknet/groth16/generating-calldata-from-a-proof-and-using-your-deployed-contract.md
+++ b/docs/gitbook/deploy-your-snark-verifier-on-starknet/groth16/generating-calldata-from-a-proof-and-using-your-deployed-contract.md
@@ -18,10 +18,10 @@ The Garaga CLI takes care of converting your proof to the correct calldata and c
 To do this, use the garaga `verify-onchain` command.&#x20;
 
 ```bash
- Usage: garaga verify-onchain [OPTIONS]                                                                                                
-                                                                                                                                       
- Invoke a SNARK verifier on Starknet given a contract address, a proof and a verification key.                                         
-                                                                                                                                       
+ Usage: garaga verify-onchain [OPTIONS]
+
+ Invoke a SNARK verifier on Starknet given a contract address, a proof and a verification key.
+
 ╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ *  --system                    [groth16]          Proof system [default: None] [required]                                           │
 │ *  --contract-address          TEXT               Starknet contract address [default: None] [required]                              │
@@ -73,7 +73,7 @@ The command should look like this:
 
 {% code overflow="wrap" %}
 ```
-garaga verify-onchain --system groth16 --address 0x1234... --vk vk.json --proof proof.json --public-inputs public.json --env-file .secrets --network sepolia 
+garaga verify-onchain --system groth16 --contract-address 0x1234... --vk vk.json --proof proof.json --public-inputs public.json --env-file .secrets --network sepolia
 ```
 {% endcode %}
 

--- a/hydra/garaga/starknet/cli/declare.py
+++ b/hydra/garaga/starknet/cli/declare.py
@@ -18,7 +18,7 @@ from garaga.starknet.cli.utils import Network, complete_fee, voyager_link_class
 app = typer.Typer()
 
 
-def declare_project(
+def declare(
     project_path: Annotated[
         Path,
         typer.Option(

--- a/hydra/garaga/starknet/cli/deploy.py
+++ b/hydra/garaga/starknet/cli/deploy.py
@@ -81,6 +81,7 @@ def deploy_project(
                         auto_estimate=True,
                         salt=1,
                         cairo_version=1,
+                        abi=[],
                     )
                 )
             elif fee.lower() == "strk":

--- a/hydra/garaga/starknet/cli/deploy.py
+++ b/hydra/garaga/starknet/cli/deploy.py
@@ -18,7 +18,7 @@ DEPLOYER_ADDRESS = 0x41A78E741E5AF2FEC34B695679BC6891742439F7AFB8484ECD7766661AD
 app = typer.Typer()
 
 
-def deploy_project(
+def deploy(
     class_hash: Annotated[
         str,
         typer.Option(

--- a/hydra/garaga/starknet/cli/starknet_cli.py
+++ b/hydra/garaga/starknet/cli/starknet_cli.py
@@ -1,7 +1,7 @@
 import typer
 
-from garaga.starknet.cli.declare import declare_project
-from garaga.starknet.cli.deploy import deploy_project
+from garaga.starknet.cli.declare import declare
+from garaga.starknet.cli.deploy import deploy
 from garaga.starknet.cli.gen import gen
 from garaga.starknet.cli.verify import calldata, verify_onchain
 
@@ -11,8 +11,8 @@ app = typer.Typer(
 )
 
 app.command(no_args_is_help=True)(gen)
-app.command(no_args_is_help=True)(declare_project)
-app.command(no_args_is_help=True)(deploy_project)
+app.command(no_args_is_help=True)(declare)
+app.command(no_args_is_help=True)(deploy)
 app.command(no_args_is_help=True)(verify_onchain)
 app.command(no_args_is_help=True)(calldata)
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [x] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

- Readme and docs are slightly inconsistent in cli command names
- Currently deploying verifier contract with fees in eth fails because the mandatory `abi` parameter is missing.

# What is the new behavior?

- Inconsistencies are resolved
- deploying verifier contract with fees paid in eth works without errors

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

Why eth and not strk: the original problem is that public faucets provide more eth than strk, and since garaga contracts are quite costly, the amount of strk you can get from faucets is not enough to deploy/interact. Although this is a separate issue that will hopefully get fixed, I think it makes sense to support paying fees in eth for all garaga interactions anyways.

There is also a commit that enables paying fees in eth for proof verification — that's changes from #256, if that PR is merged I can remove the commit. 
