### PR TITLE
Fix typo Update npm-package.md

### DIFF
--- a/docs/gitbook/installation/npm-package.md
+++ b/docs/gitbook/installation/npm-package.md
@@ -96,7 +96,7 @@ Onces changes are in place they can be made permanent into the repository by com
     npm pack
     ```
 
-5. However, before commiting changes, it is necessary to generate the WASM interoperability code in a reproducible manner using docker:
+5. However, before committing changes, it is necessary to generate the WASM interoperability code in a reproducible manner using docker:
 
     ```bash
     docker compose up --build


### PR DESCRIPTION
# Fix Typo in npm-package.md

## Description:

This pull request fixes a typographical error in the `npm-package.md` file. The word "commiting" was corrected to "committing."

## Changes:
- Corrected "commiting" to "committing" in the `npm-package.md` file.

## File(s) Modified:
- `docs/gitbook/installation/npm-package.md`

## Justification:

Correcting typographical errors ensures better readability and prevents any confusion for users following the instructions in the documentation.

## Checklist:
- [x] Typographical error corrected.
- [x] Documentation is accurate and readable.

## Related Issues:
- N/A

## Additional Notes:
This fix only involves a documentation update and does not affect the functionality of the code.
