### PR TITLE
Fix/Typos

### DIFF
--- a/docs/gitbook/using-garaga-libraries-in-your-cairo-project/ec-multi-scalar-multiplication.md
+++ b/docs/gitbook/using-garaga-libraries-in-your-cairo-project/ec-multi-scalar-multiplication.md
@@ -89,7 +89,7 @@ The options are :
 
 * `include_digits_decomposition`. This needs 162 additional felt252 per additional scalar, but it saves a lot of cairo steps. If set to `False`, the Cairo function will compute them directly in Cairo. If set to `True`, the Cairo program will verify the correctness of the decomposition (which is cheaper) and use it.
 * `include_points_and_scalars` : If set to `False`, the input points, scalars, and `curve_index` will not be part of the calldata.
-* `serialize_as_pure_felt252_array` : If set to `True`, preprend the total length of the calldata at the beginning. \
+* `serialize_as_pure_felt252_array` : If set to `True`, prepend the total length of the calldata at the beginning. \
 
 
 The last two options are only useful when you want to use points and scalars from another source than the calldata. \

--- a/src/src/groth16.cairo
+++ b/src/src/groth16.cairo
@@ -8,7 +8,7 @@
 /// MultiPairing checks circuit in the "3P_2F" mode is used for triple pairs and double fixed G2
 /// points
 ///
-/// Qf1 and Qf2 are represented by their pre-computed line functions for the specifc miller loop
+/// Qf1 and Qf2 are represented by their pre-computed line functions for the specific miller loop
 /// implementation.
 ///
 /// Two functions are provided for BN254 and BLS12-381 respectively.

--- a/src/src/groth16.cairo
+++ b/src/src/groth16.cairo
@@ -5,7 +5,7 @@
 /// The result of e(Pf4, Qf4) is precomputed and provided to the circuit as a the miller loop result
 /// precomputed_miller_loop_result = MillerLoop(Pf4, Qf4) ∈ Gt/Fp12.
 ///
-/// MultiPairing chekcs circuit in the "3P_2F" mode is used for triple pairs and double fixed G2
+/// MultiPairing checks circuit in the "3P_2F" mode is used for triple pairs and double fixed G2
 /// points
 ///
 /// Qf1 and Qf2 are represented by their pre-computed line functions for the specifc miller loop


### PR DESCRIPTION
# Pull Request: Fix Typos in Documentation and Code

This pull request corrects several typos in the project files:

### Fixed Typos:
1. **`groth16.cairo`**:
   - "chekcs" → "checks"
   - "specifc" → "specific"

2. **`ec-multi-scalar-multiplication.md`**:
   - "preprend" → "prepend"

