### PR TITLE
Noir verifier : avoid checking VK pts are on curve + add missing `shplonk_q` check. 

### DIFF
--- a/hydra/garaga/starknet/honk_contract_generator/generator_honk.py
+++ b/hydra/garaga/starknet/honk_contract_generator/generator_honk.py
@@ -76,7 +76,9 @@ def gen_honk_verifier_files(
             raise ValueError(f"Proof system {system} not compatible")
 
 
-def get_msm_kzg_template(msm_size: int, lhs_ecip_function_name: str):
+def get_msm_kzg_template(
+    msm_size: int, lhs_ecip_function_name: str, n_vk_points: int, n_proof_points: int
+):
     TEMPLATE = """\n
             full_proof.msm_hint_batched.RLCSumDlogDiv.validate_degrees_batched({msm_len});
             // HASHING: GET ECIP BASE RLC COEFF.
@@ -98,12 +100,19 @@ def get_msm_kzg_template(msm_size: int, lhs_ecip_function_name: str):
             );
 
             // Check input points are on curve. No need to hash them : they are already in the transcript + we precompute the VK hash.
-
-            for point in points {{
+            // Skip the first {n_vk_points} points as they are from VK and keep the last {n_proof_points} proof points
+            for point in points.slice({n_vk_points}, {n_proof_points}) {{
                 if !point.is_infinity() {{
                     point.assert_on_curve(0);
                 }}
             }};
+
+            // Assert shplonk_q is on curve
+            let shplonk_q_pt:G1Point = full_proof.proof.shplonk_q.into();
+
+            if !shplonk_q_pt.is_infinity() {{
+                shplonk_q_pt.assert_on_curve(0);
+            }}
 
             if !full_proof.msm_hint_batched.Q_low.is_infinity() {{
                 full_proof.msm_hint_batched.Q_low.assert_on_curve(0);
@@ -175,7 +184,7 @@ def get_msm_kzg_template(msm_size: int, lhs_ecip_function_name: str):
             let ecip_check = zk_ecip_batched_lhs == zk_ecip_batched_rhs;
 
             let P_1 = ec_safe_add(full_proof.msm_hint_batched.Q_low, full_proof.msm_hint_batched.Q_high_shifted, 0);
-            let P_1 = ec_safe_add(P_1, full_proof.proof.shplonk_q.into(), 0);
+            let P_1 = ec_safe_add(P_1, shplonk_q_pt, 0);
             let P_2:G1Point = full_proof.proof.kzg_quotient.into();
 
             // Perform the KZG pairing check.
@@ -187,7 +196,10 @@ def get_msm_kzg_template(msm_size: int, lhs_ecip_function_name: str):
             );
 
         """.format(
-        lhs_ecip_function_name=lhs_ecip_function_name, msm_len=msm_size
+        lhs_ecip_function_name=lhs_ecip_function_name,
+        msm_len=msm_size,
+        n_vk_points=n_vk_points,
+        n_proof_points=n_proof_points,
     )
     return TEMPLATE
 
@@ -401,9 +413,9 @@ pub const precomputed_lines: [G2Line; {len(precomputed_lines)//4}] = {precompute
 """
 
 
-def _get_msm_points_array_code(zk: bool) -> str:
+def _get_msm_points_array_code(zk: bool, log_n: int) -> tuple[str, (int, int)]:
     # Common points that are shared between ZK and non-ZK versions
-    common_points = [
+    vk_points = [
         "vk.qm",
         "vk.qc",
         "vk.ql",
@@ -431,43 +443,60 @@ def _get_msm_points_array_code(zk: bool) -> str:
         "vk.t4",
         "vk.lagrange_first",
         "vk.lagrange_last",
-        "full_proof.proof.w1.into()",
-        "full_proof.proof.w2.into()",
-        "full_proof.proof.w3.into()",
-        "full_proof.proof.w4.into()",
-        "full_proof.proof.z_perm.into()",
-        "full_proof.proof.lookup_inverses.into()",
-        "full_proof.proof.lookup_read_counts.into()",
-        "full_proof.proof.lookup_read_tags.into()",
     ]
 
-    # ZK-specific points that are added at the beginning
-    zk_points = ["full_proof.proof.gemini_masking_poly.into()"] if zk else []
+    next_proof_point_counter = 1
+    proof_points = (
+        [
+            f"full_proof.proof.gemini_masking_poly.into(), // Proof point {next_proof_point_counter}"
+        ]
+        if zk
+        else []
+    )
+    next_proof_point_counter += 1 if zk else 0
+
+    proof_points += [
+        f"full_proof.proof.w1.into(), // Proof point {next_proof_point_counter}",
+        f"full_proof.proof.w2.into(), // Proof point {next_proof_point_counter+1}",
+        f"full_proof.proof.w3.into(), // Proof point {next_proof_point_counter+2}",
+        f"full_proof.proof.w4.into(), // Proof point {next_proof_point_counter+3}",
+        f"full_proof.proof.z_perm.into(), // Proof point {next_proof_point_counter+4}",
+        f"full_proof.proof.lookup_inverses.into(), // Proof point {next_proof_point_counter+5}",
+        f"full_proof.proof.lookup_read_counts.into(), // Proof point {next_proof_point_counter+6}",
+        f"full_proof.proof.lookup_read_tags.into(), // Proof point {next_proof_point_counter+7}",
+    ]
+    next_proof_point_counter += 8
 
     # Combine all points
-    all_points = zk_points + common_points
+    all_points = vk_points + proof_points
+
     points_str = ",\n".join(all_points)
     code = "// Starts with 1 * shplonk_q, not included in msm\n"
-    code += f"""            let mut _points: Array<G1Point> = array![{points_str}];
+    code += f"""            let mut _points: Array<G1Point> = array![{points_str}\n];
 
             for gem_comm in full_proof.proof.gemini_fold_comms {{
                 _points.append((*gem_comm).into());
-            }};"""
+            }}; // log_n -1 = {log_n-1} points || Proof points {next_proof_point_counter}-{next_proof_point_counter+(log_n-1) - 1}"""
+    next_proof_point_counter += log_n - 1
     # Add ZK-specific commitments
     if zk:
-        code += """
-            for lib_comm in full_proof.proof.libra_commitments {
+        code += f"""
+            for lib_comm in full_proof.proof.libra_commitments {{
                 _points.append((*lib_comm).into());
-            };"""
-
+            }};// 3 points || Proof points {next_proof_point_counter}-{next_proof_point_counter+3-1}"""
+        next_proof_point_counter += 3
     # Add common final points
-    code += """
-            _points.append(full_proof.proof.kzg_quotient.into());
+    code += f"""
+            _points.append(full_proof.proof.kzg_quotient.into()); // Proof point {next_proof_point_counter}
             _points.append(BN254_G1_GENERATOR);
 
             let points = _points.span();"""
 
-    return code
+    proof_point_counter = next_proof_point_counter
+
+    n_vk_points = len(vk_points)
+
+    return code, (n_vk_points, proof_point_counter)
 
 
 def _gen_honk_verifier_files(
@@ -511,6 +540,10 @@ def _gen_honk_verifier_files(
         ],
     )
 
+    points_code, (n_vk_points, n_proof_points) = _get_msm_points_array_code(
+        zk=False, log_n=vk.log_circuit_size
+    )
+
     contract_code = f"""{contract_header}
             let (transcript, transcript_state, base_rlc) = HonkTranscriptTrait::from_proof::<{flavor}HasherState>(vk.circuit_size, vk.public_inputs_size, vk.public_inputs_offset, full_proof.proof);
             let log_n = vk.log_circuit_size;
@@ -543,11 +576,11 @@ def _gen_honk_verifier_files(
             tp_sum_check_u_challenges: transcript.sum_check_u_challenges.span().slice(0, log_n),
         );
 
-            {_get_msm_points_array_code(zk=False)}
+            {points_code}
 
             let scalars: Span<u256> = array![{scalars_tuple_into}].span();
 
-            {get_msm_kzg_template(msm_len, lhs_ecip_function_name)}
+            {get_msm_kzg_template(msm_len, lhs_ecip_function_name, n_vk_points, n_proof_points)}
 
             if sum_check_rlc.is_zero() && honk_check.is_zero() && ecip_check && kzg_check {{
                 return Option::Some(full_proof.proof.public_inputs);
@@ -584,14 +617,25 @@ def _gen_zk_honk_verifier_files(
         msm_len,
     ) = _gen_circuits_code(vk, True)
 
+    points_code, (n_vk_points, n_proof_points) = _get_msm_points_array_code(
+        zk=True, log_n=vk.log_circuit_size
+    )
+
     scalars_tuple = ",\n            ".join(f"scalar_{idx}" for idx in scalar_indexes)
     scalars_tuple_into = [
         f"into_u256_unchecked(scalar_{idx})" for idx in scalar_indexes
     ]
 
     scalars_tuple_into.append("transcript.shplonk_z.into()")
-    # Swap position of last two elements of scalars_tuple_into :
+    # Swap position of last two elements of scalars_tuple_into (KZG quotient & BN254 G1 generator) :
     scalars_tuple_into = scalars_tuple_into[:-2] + scalars_tuple_into[-2:][::-1]
+    # Move first scalar after the first vk points [a, b, c, d, e] -> [b,c,d,a,e] if [b,c,d] are vk points:
+    scalars_tuple_into = (
+        scalars_tuple_into[1 : n_vk_points + 1]
+        + scalars_tuple_into[:1]
+        + scalars_tuple_into[n_vk_points + 1 :]
+    )
+
     scalars_tuple_into = ",\n            ".join(scalars_tuple_into)
 
     # Generate contract header
@@ -666,10 +710,10 @@ def _gen_zk_honk_verifier_files(
             tp_sum_check_u_challenges: transcript.sum_check_u_challenges.span().slice(0, log_n),
         );
 
-            {_get_msm_points_array_code(zk=True)}
+            {points_code}
             let scalars: Span<u256> = array![{scalars_tuple_into}].span();
 
-            {get_msm_kzg_template(msm_len, lhs_ecip_function_name)}
+            {get_msm_kzg_template(msm_len, lhs_ecip_function_name, n_vk_points, n_proof_points)}
             if sum_check_rlc.is_zero() && honk_check.is_zero() && !vanishing_check.is_zero() && diff_check.is_zero() && ecip_check && kzg_check {{
                 return Option::Some(full_proof.proof.public_inputs);
             }} else {{

--- a/src/contracts/autogenerated/noir_ultra_keccak_honk_example/src/honk_verifier.cairo
+++ b/src/contracts/autogenerated/noir_ultra_keccak_honk_example/src/honk_verifier.cairo
@@ -179,8 +179,8 @@ mod UltraKeccakHonkVerifier {
             for gem_comm in full_proof.proof.gemini_fold_comms {
                 _points.append((*gem_comm).into());
             }
-            _points.append(BN254_G1_GENERATOR);
             _points.append(full_proof.proof.kzg_quotient.into());
+            _points.append(BN254_G1_GENERATOR);
 
             let points = _points.span();
 
@@ -224,8 +224,8 @@ mod UltraKeccakHonkVerifier {
                 into_u256_unchecked(scalar_42),
                 into_u256_unchecked(scalar_43),
                 into_u256_unchecked(scalar_44),
-                into_u256_unchecked(scalar_68),
                 transcript.shplonk_z.into(),
+                into_u256_unchecked(scalar_68),
             ]
                 .span();
 

--- a/src/contracts/autogenerated/noir_ultra_keccak_honk_example/src/honk_verifier.cairo
+++ b/src/contracts/autogenerated/noir_ultra_keccak_honk_example/src/honk_verifier.cairo
@@ -166,20 +166,20 @@ mod UltraKeccakHonkVerifier {
                 vk.t4,
                 vk.lagrange_first,
                 vk.lagrange_last,
-                full_proof.proof.w1.into(),
-                full_proof.proof.w2.into(),
-                full_proof.proof.w3.into(),
-                full_proof.proof.w4.into(),
-                full_proof.proof.z_perm.into(),
-                full_proof.proof.lookup_inverses.into(),
-                full_proof.proof.lookup_read_counts.into(),
-                full_proof.proof.lookup_read_tags.into(),
+                full_proof.proof.w1.into(), // Proof point 1,
+                full_proof.proof.w2.into(), // Proof point 2,
+                full_proof.proof.w3.into(), // Proof point 3,
+                full_proof.proof.w4.into(), // Proof point 4,
+                full_proof.proof.z_perm.into(), // Proof point 5,
+                full_proof.proof.lookup_inverses.into(), // Proof point 6,
+                full_proof.proof.lookup_read_counts.into(), // Proof point 7,
+                full_proof.proof.lookup_read_tags.into() // Proof point 8
             ];
 
             for gem_comm in full_proof.proof.gemini_fold_comms {
                 _points.append((*gem_comm).into());
-            }
-            _points.append(full_proof.proof.kzg_quotient.into());
+            } // log_n -1 = 4 points || Proof points 9-12
+            _points.append(full_proof.proof.kzg_quotient.into()); // Proof point 13
             _points.append(BN254_G1_GENERATOR);
 
             let points = _points.span();
@@ -246,11 +246,18 @@ mod UltraKeccakHonkVerifier {
 
             // Check input points are on curve. No need to hash them : they are already in the
             // transcript + we precompute the VK hash.
-
-            for point in points {
+            // Skip the first 27 points as they are from VK and keep the last 13 proof points
+            for point in points.slice(27, 13) {
                 if !point.is_infinity() {
                     point.assert_on_curve(0);
                 }
+            }
+
+            // Assert shplonk_q is on curve
+            let shplonk_q_pt: G1Point = full_proof.proof.shplonk_q.into();
+
+            if !shplonk_q_pt.is_infinity() {
+                shplonk_q_pt.assert_on_curve(0);
             }
 
             if !full_proof.msm_hint_batched.Q_low.is_infinity() {
@@ -356,7 +363,7 @@ mod UltraKeccakHonkVerifier {
             let P_1 = ec_safe_add(
                 full_proof.msm_hint_batched.Q_low, full_proof.msm_hint_batched.Q_high_shifted, 0,
             );
-            let P_1 = ec_safe_add(P_1, full_proof.proof.shplonk_q.into(), 0);
+            let P_1 = ec_safe_add(P_1, shplonk_q_pt, 0);
             let P_2: G1Point = full_proof.proof.kzg_quotient.into();
 
             // Perform the KZG pairing check.

--- a/src/contracts/autogenerated/noir_ultra_keccak_zk_honk_example/src/honk_verifier.cairo
+++ b/src/contracts/autogenerated/noir_ultra_keccak_zk_honk_example/src/honk_verifier.cairo
@@ -177,7 +177,6 @@ mod UltraKeccakZKHonkVerifier {
 
             // Starts with 1 * shplonk_q, not included in msm
             let mut _points: Array<G1Point> = array![
-                full_proof.proof.gemini_masking_poly.into(),
                 vk.qm,
                 vk.qc,
                 vk.ql,
@@ -205,28 +204,28 @@ mod UltraKeccakZKHonkVerifier {
                 vk.t4,
                 vk.lagrange_first,
                 vk.lagrange_last,
-                full_proof.proof.w1.into(),
-                full_proof.proof.w2.into(),
-                full_proof.proof.w3.into(),
-                full_proof.proof.w4.into(),
-                full_proof.proof.z_perm.into(),
-                full_proof.proof.lookup_inverses.into(),
-                full_proof.proof.lookup_read_counts.into(),
-                full_proof.proof.lookup_read_tags.into(),
+                full_proof.proof.gemini_masking_poly.into(), // Proof point 1,
+                full_proof.proof.w1.into(), // Proof point 2,
+                full_proof.proof.w2.into(), // Proof point 3,
+                full_proof.proof.w3.into(), // Proof point 4,
+                full_proof.proof.w4.into(), // Proof point 5,
+                full_proof.proof.z_perm.into(), // Proof point 6,
+                full_proof.proof.lookup_inverses.into(), // Proof point 7,
+                full_proof.proof.lookup_read_counts.into(), // Proof point 8,
+                full_proof.proof.lookup_read_tags.into() // Proof point 9
             ];
 
             for gem_comm in full_proof.proof.gemini_fold_comms {
                 _points.append((*gem_comm).into());
-            }
+            } // log_n -1 = 4 points || Proof points 10-13
             for lib_comm in full_proof.proof.libra_commitments {
                 _points.append((*lib_comm).into());
-            }
-            _points.append(full_proof.proof.kzg_quotient.into());
+            } // 3 points || Proof points 14-16
+            _points.append(full_proof.proof.kzg_quotient.into()); // Proof point 17
             _points.append(BN254_G1_GENERATOR);
 
             let points = _points.span();
             let scalars: Span<u256> = array![
-                into_u256_unchecked(scalar_1),
                 into_u256_unchecked(scalar_2),
                 into_u256_unchecked(scalar_3),
                 into_u256_unchecked(scalar_4),
@@ -254,6 +253,7 @@ mod UltraKeccakZKHonkVerifier {
                 into_u256_unchecked(scalar_26),
                 into_u256_unchecked(scalar_27),
                 into_u256_unchecked(scalar_28),
+                into_u256_unchecked(scalar_1),
                 into_u256_unchecked(scalar_29),
                 into_u256_unchecked(scalar_30),
                 into_u256_unchecked(scalar_31),
@@ -291,11 +291,18 @@ mod UltraKeccakZKHonkVerifier {
 
             // Check input points are on curve. No need to hash them : they are already in the
             // transcript + we precompute the VK hash.
-
-            for point in points {
+            // Skip the first 27 points as they are from VK and keep the last 17 proof points
+            for point in points.slice(27, 17) {
                 if !point.is_infinity() {
                     point.assert_on_curve(0);
                 }
+            }
+
+            // Assert shplonk_q is on curve
+            let shplonk_q_pt: G1Point = full_proof.proof.shplonk_q.into();
+
+            if !shplonk_q_pt.is_infinity() {
+                shplonk_q_pt.assert_on_curve(0);
             }
 
             if !full_proof.msm_hint_batched.Q_low.is_infinity() {
@@ -401,7 +408,7 @@ mod UltraKeccakZKHonkVerifier {
             let P_1 = ec_safe_add(
                 full_proof.msm_hint_batched.Q_low, full_proof.msm_hint_batched.Q_high_shifted, 0,
             );
-            let P_1 = ec_safe_add(P_1, full_proof.proof.shplonk_q.into(), 0);
+            let P_1 = ec_safe_add(P_1, shplonk_q_pt, 0);
             let P_2: G1Point = full_proof.proof.kzg_quotient.into();
 
             // Perform the KZG pairing check.

--- a/src/contracts/autogenerated/noir_ultra_keccak_zk_honk_example/src/honk_verifier.cairo
+++ b/src/contracts/autogenerated/noir_ultra_keccak_zk_honk_example/src/honk_verifier.cairo
@@ -221,8 +221,8 @@ mod UltraKeccakZKHonkVerifier {
             for lib_comm in full_proof.proof.libra_commitments {
                 _points.append((*lib_comm).into());
             }
-            _points.append(BN254_G1_GENERATOR);
             _points.append(full_proof.proof.kzg_quotient.into());
+            _points.append(BN254_G1_GENERATOR);
 
             let points = _points.span();
             let scalars: Span<u256> = array![
@@ -269,8 +269,8 @@ mod UltraKeccakZKHonkVerifier {
                 into_u256_unchecked(scalar_69),
                 into_u256_unchecked(scalar_70),
                 into_u256_unchecked(scalar_71),
-                into_u256_unchecked(scalar_72),
                 transcript.shplonk_z.into(),
+                into_u256_unchecked(scalar_72),
             ]
                 .span();
 

--- a/src/contracts/autogenerated/noir_ultra_starknet_honk_example/src/honk_verifier.cairo
+++ b/src/contracts/autogenerated/noir_ultra_starknet_honk_example/src/honk_verifier.cairo
@@ -179,8 +179,8 @@ mod UltraStarknetHonkVerifier {
             for gem_comm in full_proof.proof.gemini_fold_comms {
                 _points.append((*gem_comm).into());
             }
-            _points.append(BN254_G1_GENERATOR);
             _points.append(full_proof.proof.kzg_quotient.into());
+            _points.append(BN254_G1_GENERATOR);
 
             let points = _points.span();
 
@@ -224,8 +224,8 @@ mod UltraStarknetHonkVerifier {
                 into_u256_unchecked(scalar_42),
                 into_u256_unchecked(scalar_43),
                 into_u256_unchecked(scalar_44),
-                into_u256_unchecked(scalar_68),
                 transcript.shplonk_z.into(),
+                into_u256_unchecked(scalar_68),
             ]
                 .span();
 

--- a/src/contracts/autogenerated/noir_ultra_starknet_honk_example/src/honk_verifier.cairo
+++ b/src/contracts/autogenerated/noir_ultra_starknet_honk_example/src/honk_verifier.cairo
@@ -166,20 +166,20 @@ mod UltraStarknetHonkVerifier {
                 vk.t4,
                 vk.lagrange_first,
                 vk.lagrange_last,
-                full_proof.proof.w1.into(),
-                full_proof.proof.w2.into(),
-                full_proof.proof.w3.into(),
-                full_proof.proof.w4.into(),
-                full_proof.proof.z_perm.into(),
-                full_proof.proof.lookup_inverses.into(),
-                full_proof.proof.lookup_read_counts.into(),
-                full_proof.proof.lookup_read_tags.into(),
+                full_proof.proof.w1.into(), // Proof point 1,
+                full_proof.proof.w2.into(), // Proof point 2,
+                full_proof.proof.w3.into(), // Proof point 3,
+                full_proof.proof.w4.into(), // Proof point 4,
+                full_proof.proof.z_perm.into(), // Proof point 5,
+                full_proof.proof.lookup_inverses.into(), // Proof point 6,
+                full_proof.proof.lookup_read_counts.into(), // Proof point 7,
+                full_proof.proof.lookup_read_tags.into() // Proof point 8
             ];
 
             for gem_comm in full_proof.proof.gemini_fold_comms {
                 _points.append((*gem_comm).into());
-            }
-            _points.append(full_proof.proof.kzg_quotient.into());
+            } // log_n -1 = 4 points || Proof points 9-12
+            _points.append(full_proof.proof.kzg_quotient.into()); // Proof point 13
             _points.append(BN254_G1_GENERATOR);
 
             let points = _points.span();
@@ -246,11 +246,18 @@ mod UltraStarknetHonkVerifier {
 
             // Check input points are on curve. No need to hash them : they are already in the
             // transcript + we precompute the VK hash.
-
-            for point in points {
+            // Skip the first 27 points as they are from VK and keep the last 13 proof points
+            for point in points.slice(27, 13) {
                 if !point.is_infinity() {
                     point.assert_on_curve(0);
                 }
+            }
+
+            // Assert shplonk_q is on curve
+            let shplonk_q_pt: G1Point = full_proof.proof.shplonk_q.into();
+
+            if !shplonk_q_pt.is_infinity() {
+                shplonk_q_pt.assert_on_curve(0);
             }
 
             if !full_proof.msm_hint_batched.Q_low.is_infinity() {
@@ -356,7 +363,7 @@ mod UltraStarknetHonkVerifier {
             let P_1 = ec_safe_add(
                 full_proof.msm_hint_batched.Q_low, full_proof.msm_hint_batched.Q_high_shifted, 0,
             );
-            let P_1 = ec_safe_add(P_1, full_proof.proof.shplonk_q.into(), 0);
+            let P_1 = ec_safe_add(P_1, shplonk_q_pt, 0);
             let P_2: G1Point = full_proof.proof.kzg_quotient.into();
 
             // Perform the KZG pairing check.

--- a/src/contracts/autogenerated/noir_ultra_starknet_zk_honk_example/src/honk_verifier.cairo
+++ b/src/contracts/autogenerated/noir_ultra_starknet_zk_honk_example/src/honk_verifier.cairo
@@ -221,8 +221,8 @@ mod UltraStarknetZKHonkVerifier {
             for lib_comm in full_proof.proof.libra_commitments {
                 _points.append((*lib_comm).into());
             }
-            _points.append(BN254_G1_GENERATOR);
             _points.append(full_proof.proof.kzg_quotient.into());
+            _points.append(BN254_G1_GENERATOR);
 
             let points = _points.span();
             let scalars: Span<u256> = array![
@@ -269,8 +269,8 @@ mod UltraStarknetZKHonkVerifier {
                 into_u256_unchecked(scalar_69),
                 into_u256_unchecked(scalar_70),
                 into_u256_unchecked(scalar_71),
-                into_u256_unchecked(scalar_72),
                 transcript.shplonk_z.into(),
+                into_u256_unchecked(scalar_72),
             ]
                 .span();
 

--- a/src/contracts/mutator_set/src/lib.cairo
+++ b/src/contracts/mutator_set/src/lib.cairo
@@ -7,4 +7,4 @@ pub mod zk_verifier {
 }
 
 const VERIFIER_CLASS_HASH: felt252 =
-    0x001f2245a569845060e985dc56dda22711f12a4527772dbd53c297a871ae604d;
+    0x02a84036ec0806aa155ac6b6b05d089b5b9309d6ea9e0f8dc23b5d0575f58f85;

--- a/src/contracts/mutator_set/src/lib.cairo
+++ b/src/contracts/mutator_set/src/lib.cairo
@@ -7,4 +7,4 @@ pub mod zk_verifier {
 }
 
 const VERIFIER_CLASS_HASH: felt252 =
-    0x02a84036ec0806aa155ac6b6b05d089b5b9309d6ea9e0f8dc23b5d0575f58f85;
+    0x01afe9b50480c9b280732c4825f006231dcce1efc991d9f32103f74e96c83a79;

--- a/src/contracts/mutator_set/src/zk_verifier/honk_verifier_contract.cairo
+++ b/src/contracts/mutator_set/src/zk_verifier/honk_verifier_contract.cairo
@@ -177,7 +177,6 @@ mod UltraKeccakZKHonkVerifier {
 
             // Starts with 1 * shplonk_q, not included in msm
             let mut _points: Array<G1Point> = array![
-                full_proof.proof.gemini_masking_poly.into(),
                 vk.qm,
                 vk.qc,
                 vk.ql,
@@ -205,28 +204,28 @@ mod UltraKeccakZKHonkVerifier {
                 vk.t4,
                 vk.lagrange_first,
                 vk.lagrange_last,
-                full_proof.proof.w1.into(),
-                full_proof.proof.w2.into(),
-                full_proof.proof.w3.into(),
-                full_proof.proof.w4.into(),
-                full_proof.proof.z_perm.into(),
-                full_proof.proof.lookup_inverses.into(),
-                full_proof.proof.lookup_read_counts.into(),
-                full_proof.proof.lookup_read_tags.into(),
+                full_proof.proof.gemini_masking_poly.into(), // Proof point 1,
+                full_proof.proof.w1.into(), // Proof point 2,
+                full_proof.proof.w2.into(), // Proof point 3,
+                full_proof.proof.w3.into(), // Proof point 4,
+                full_proof.proof.w4.into(), // Proof point 5,
+                full_proof.proof.z_perm.into(), // Proof point 6,
+                full_proof.proof.lookup_inverses.into(), // Proof point 7,
+                full_proof.proof.lookup_read_counts.into(), // Proof point 8,
+                full_proof.proof.lookup_read_tags.into() // Proof point 9
             ];
 
             for gem_comm in full_proof.proof.gemini_fold_comms {
                 _points.append((*gem_comm).into());
-            }
+            } // log_n -1 = 4 points || Proof points 10-13
             for lib_comm in full_proof.proof.libra_commitments {
                 _points.append((*lib_comm).into());
-            }
-            _points.append(full_proof.proof.kzg_quotient.into());
+            } // 3 points || Proof points 14-16
+            _points.append(full_proof.proof.kzg_quotient.into()); // Proof point 17
             _points.append(BN254_G1_GENERATOR);
 
             let points = _points.span();
             let scalars: Span<u256> = array![
-                into_u256_unchecked(scalar_1),
                 into_u256_unchecked(scalar_2),
                 into_u256_unchecked(scalar_3),
                 into_u256_unchecked(scalar_4),
@@ -254,6 +253,7 @@ mod UltraKeccakZKHonkVerifier {
                 into_u256_unchecked(scalar_26),
                 into_u256_unchecked(scalar_27),
                 into_u256_unchecked(scalar_28),
+                into_u256_unchecked(scalar_1),
                 into_u256_unchecked(scalar_29),
                 into_u256_unchecked(scalar_30),
                 into_u256_unchecked(scalar_31),
@@ -291,11 +291,18 @@ mod UltraKeccakZKHonkVerifier {
 
             // Check input points are on curve. No need to hash them : they are already in the
             // transcript + we precompute the VK hash.
-
-            for point in points {
+            // Skip the first 27 points as they are from VK and keep the last 17 proof points
+            for point in points.slice(27, 17) {
                 if !point.is_infinity() {
                     point.assert_on_curve(0);
                 }
+            }
+
+            // Assert shplonk_q is on curve
+            let shplonk_q_pt: G1Point = full_proof.proof.shplonk_q.into();
+
+            if !shplonk_q_pt.is_infinity() {
+                shplonk_q_pt.assert_on_curve(0);
             }
 
             if !full_proof.msm_hint_batched.Q_low.is_infinity() {
@@ -401,7 +408,7 @@ mod UltraKeccakZKHonkVerifier {
             let P_1 = ec_safe_add(
                 full_proof.msm_hint_batched.Q_low, full_proof.msm_hint_batched.Q_high_shifted, 0,
             );
-            let P_1 = ec_safe_add(P_1, full_proof.proof.shplonk_q.into(), 0);
+            let P_1 = ec_safe_add(P_1, shplonk_q_pt, 0);
             let P_2: G1Point = full_proof.proof.kzg_quotient.into();
 
             // Perform the KZG pairing check.

--- a/src/contracts/mutator_set/src/zk_verifier/honk_verifier_contract.cairo
+++ b/src/contracts/mutator_set/src/zk_verifier/honk_verifier_contract.cairo
@@ -221,8 +221,8 @@ mod UltraKeccakZKHonkVerifier {
             for lib_comm in full_proof.proof.libra_commitments {
                 _points.append((*lib_comm).into());
             }
-            _points.append(BN254_G1_GENERATOR);
             _points.append(full_proof.proof.kzg_quotient.into());
+            _points.append(BN254_G1_GENERATOR);
 
             let points = _points.span();
             let scalars: Span<u256> = array![
@@ -269,8 +269,8 @@ mod UltraKeccakZKHonkVerifier {
                 into_u256_unchecked(scalar_69),
                 into_u256_unchecked(scalar_70),
                 into_u256_unchecked(scalar_71),
-                into_u256_unchecked(scalar_72),
                 transcript.shplonk_z.into(),
+                into_u256_unchecked(scalar_72),
             ]
                 .span();
 


### PR DESCRIPTION
Re-organize the order of msm points in the contract to use .slice() on proof point for curve checks to avoid unnecessary check on vk points. 
Shplonk_q was not in the points array and on curve check for it was missing