### PR TITLE
Export groth16 parsing utils

### DIFF
--- a/tools/npm/garaga_ts/src/node/api.ts
+++ b/tools/npm/garaga_ts/src/node/api.ts
@@ -19,6 +19,11 @@ import { CurveId } from './definitions';
 import { Groth16Proof, Groth16VerifyingKey } from './starknet/groth16ContractGenerator/parsingUtils';
 import { HonkFlavor } from './starknet/honkContractGenerator/parsingUtils';
 
+export {
+  parseGroth16ProofFromObject,
+  parseGroth16VerifyingKeyFromObject,
+} from './starknet/groth16ContractGenerator/parsingUtils';
+
 /**
  * Represents a point on an elliptic curve in affine coordinates (x, y)
  */

--- a/tools/npm/garaga_ts/src/node/api.ts
+++ b/tools/npm/garaga_ts/src/node/api.ts
@@ -20,8 +20,10 @@ import { Groth16Proof, Groth16VerifyingKey } from './starknet/groth16ContractGen
 import { HonkFlavor } from './starknet/honkContractGenerator/parsingUtils';
 
 export {
+  parseGroth16ProofFromJson,
   parseGroth16ProofFromObject,
   parseGroth16VerifyingKeyFromObject,
+  parseGroth16VerifyingKeyFromJson,
 } from './starknet/groth16ContractGenerator/parsingUtils';
 
 /**


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

`getGroth16CallData()` is public, but there’s no way to parse proof and verification key files. 

Issue Number: N/A

# What is the new behavior?

This PR exposes the following helpers:

- `parseGroth16ProofFromJson`
- `parseGroth16ProofFromObject`
- `parseGroth16VerifyingKeyFromJson`
- `parseGroth16VerifyingKeyFromObject`

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
