### PR TITLE
feat: bls_calldata_builder for arbitrary BLS12-381 messages

### DIFF
--- a/src/contracts/bls_verifier/Scarb.toml
+++ b/src/contracts/bls_verifier/Scarb.toml
@@ -1,0 +1,17 @@
+[package]
+name = "bls_verifier"
+version = "0.1.0"
+edition = "2024_07"
+
+[dependencies]
+garaga = { path = "../.." }
+starknet = "2.16.1"
+
+[lib]
+
+[cairo]
+sierra-replace-ids = false
+
+[[target.starknet-contract]]
+casm = true
+casm-add-pythonic-hints = true

--- a/src/contracts/bls_verifier/src/bls_verifier.cairo
+++ b/src/contracts/bls_verifier/src/bls_verifier.cairo
@@ -1,0 +1,147 @@
+//! Reference BLS12-381 min-sig-size verifier (drand DST).
+//!
+//! Counterpart to `drand_quicknet/src/drand_verifier.cairo` but with
+//! the chain-specific gates lifted: caller supplies the message hash
+//! and a per-call G2 public key, so the same class verifies arbitrary
+//! BLS signatures (validator multisigs, DAO governance keys, backend
+//! signers).
+//!
+//! Calldata layout matches `garaga::calldata::bls_calldata_builder`'s
+//! output (minus the size prefix consumed by the Span<felt252>
+//! transport). See `tools/garaga_rs/src/calldata/bls_calldata.rs` for
+//! the full envelope description.
+
+#[starknet::interface]
+pub trait IBlsVerifier<TContractState> {
+    fn verify_bls_signature(
+        self: @TContractState,
+        message_hash: felt252,
+        pubkey: garaga::definitions::G2Point,
+        full_proof_with_hints: Span<felt252>,
+    ) -> bool;
+}
+
+#[starknet::contract]
+pub mod BlsVerifier {
+    use core::array::{ArrayTrait, SpanTrait};
+    use core::circuit::u384;
+    use core::option::OptionTrait;
+    use core::serde::Serde;
+    use core::traits::{Into, TryInto};
+    use garaga::apps::drand::{HashToCurveHint, hash_to_curve_bls12_381};
+    use garaga::definitions::structs::fields::deserialize_u384;
+    use garaga::definitions::structs::points::G2Line;
+    use garaga::definitions::{BLS_G2_GENERATOR, G1G2Pair, G1Point, G2Point};
+    use garaga::ec::ec_ops::G1PointTrait;
+    use garaga::ec::ec_ops_g2::G2PointTrait;
+    use garaga::ec::pairing::pairing_check::multi_pairing_check_bls12_381_2P_2F;
+    use garaga::pairing_check::MPCheckHintBLS12_381;
+    use garaga::utils::calldata::deserialize_mpcheck_hint_bls12_381;
+
+    /// Number of precomputed Miller-loop lines for `multi_pairing_check_bls12_381_2P_2F`
+    /// with two precomputed G2 points.
+    const BLS_2P_2F_LINES_LEN: u32 = 136;
+
+    /// BLS12-381 curve index used by Garaga's subgroup checks.
+    const BLS_CURVE_INDEX: usize = 1;
+
+    #[storage]
+    struct Storage {}
+
+    #[abi(embed_v0)]
+    impl IBlsVerifierImpl of super::IBlsVerifier<ContractState> {
+        fn verify_bls_signature(
+            self: @ContractState,
+            message_hash: felt252,
+            pubkey: G2Point,
+            mut full_proof_with_hints: Span<felt252>,
+        ) -> bool {
+            // ---------- 1. parse signature G1 ----------
+            let signature_g1: G1Point =
+                match Serde::<G1Point>::deserialize(ref full_proof_with_hints) {
+                Option::Some(s) => s,
+                Option::None => { return false; },
+            };
+
+            // ---------- 2. parse hash-to-curve hint ----------
+            let h2c_hint: HashToCurveHint =
+                match Serde::<HashToCurveHint>::deserialize(ref full_proof_with_hints) {
+                Option::Some(h) => h,
+                Option::None => { return false; },
+            };
+
+            // ---------- 3. parse precomputed Miller-loop lines ----------
+            let lines_len_felt: felt252 = match full_proof_with_hints.pop_front() {
+                Option::Some(v) => *v,
+                Option::None => { return false; },
+            };
+            let lines_len: u32 = match lines_len_felt.try_into() {
+                Option::Some(n) => n,
+                Option::None => { return false; },
+            };
+            if lines_len != BLS_2P_2F_LINES_LEN {
+                return false;
+            }
+            let mut lines_arr: Array<G2Line<u384>> = ArrayTrait::new();
+            let mut i: u32 = 0;
+            while i != lines_len {
+                let r0a0 = deserialize_u384(ref full_proof_with_hints);
+                let r0a1 = deserialize_u384(ref full_proof_with_hints);
+                let r1a0 = deserialize_u384(ref full_proof_with_hints);
+                let r1a1 = deserialize_u384(ref full_proof_with_hints);
+                lines_arr.append(G2Line { r0a0, r0a1, r1a0, r1a1 });
+                i += 1;
+            }
+
+            // ---------- 4. parse mpcheck hint ----------
+            // Helper consumes the rest of the span; panics on truncation
+            // (correct failure mode for a structurally malformed envelope).
+            let mpcheck_hint: MPCheckHintBLS12_381 = deserialize_mpcheck_hint_bls12_381(
+                ref full_proof_with_hints,
+            );
+
+            // ---------- 5. subgroup checks ----------
+            pubkey.assert_in_subgroup_excluding_infinity(BLS_CURVE_INDEX);
+            signature_g1.assert_in_subgroup_excluding_infinity(BLS_CURVE_INDEX);
+
+            // ---------- 6. felt252 → [u32; 8] big-endian ----------
+            let msg_u32s = felt252_to_u32x8_be(message_hash);
+
+            // ---------- 7. compute H(m) on chain ----------
+            let msg_pt = hash_to_curve_bls12_381(msg_u32s, h2c_hint);
+
+            // ---------- 8. multi-pairing check ----------
+            // BLS verify identity: e(sig, G2_GEN) == e(H(m), pubkey)
+            //   ⇔ e(sig, G2_GEN) · e(H(m), -pubkey) == 1
+            let neg_pubkey = pubkey.negate(BLS_CURVE_INDEX);
+            let result = multi_pairing_check_bls12_381_2P_2F(
+                pair0: G1G2Pair { p: signature_g1, q: BLS_G2_GENERATOR },
+                pair1: G1G2Pair { p: msg_pt, q: neg_pubkey },
+                lines: lines_arr.span(),
+                hint: mpcheck_hint,
+            );
+            match result {
+                Result::Ok(_) => true,
+                Result::Err(_) => false,
+            }
+        }
+    }
+
+    /// Convert a `felt252` (≤252 bits) to its 32-byte big-endian
+    /// representation, then split into eight u32 big-endian words.
+    fn felt252_to_u32x8_be(m: felt252) -> [u32; 8] {
+        let m_u256: u256 = m.into();
+        let high: u128 = m_u256.high;
+        let low: u128 = m_u256.low;
+
+        let h0: u32 = (high / 0x1000000000000000000000000_u128).try_into().unwrap();
+        let h1: u32 = ((high / 0x10000000000000000_u128) & 0xffffffff_u128).try_into().unwrap();
+        let h2: u32 = ((high / 0x100000000_u128) & 0xffffffff_u128).try_into().unwrap();
+        let h3: u32 = (high & 0xffffffff_u128).try_into().unwrap();
+        let l0: u32 = (low / 0x1000000000000000000000000_u128).try_into().unwrap();
+        let l1: u32 = ((low / 0x10000000000000000_u128) & 0xffffffff_u128).try_into().unwrap();
+        let l2: u32 = ((low / 0x100000000_u128) & 0xffffffff_u128).try_into().unwrap();
+        let l3: u32 = (low & 0xffffffff_u128).try_into().unwrap();
+        [h0, h1, h2, h3, l0, l1, l2, l3]
+    }
+}

--- a/src/contracts/bls_verifier/src/lib.cairo
+++ b/src/contracts/bls_verifier/src/lib.cairo
@@ -1,0 +1,1 @@
+pub mod bls_verifier;

--- a/tests/contracts_e2e/e2e_test.py
+++ b/tests/contracts_e2e/e2e_test.py
@@ -561,3 +561,163 @@ async def test_risc0_sample_app(account_devnet: BaseAccount):
 
     receipt = await account.client.get_transaction_receipt(invoke_result.hash)
     print(receipt.execution_resources)
+
+
+# ----------------------------------------------------------------
+#  Generic BLS12-381 (min-sig-size, drand DST) verifier E2E
+# ----------------------------------------------------------------
+#
+# Counterpart to test_drand_contract above, but exercising the
+# generic `bls_calldata_builder` (issue #518, this PR) against a
+# reference verifier under `src/contracts/bls_verifier/`. The
+# verifier accepts an arbitrary 32-byte message digest and a
+# per-call G2 public key, so the same class authenticates any BLS
+# signer (validator multisigs, DAO governance keys, backend signers).
+
+
+def _compress_g1_bls(p) -> bytes:
+    """BLS12-381 compressed G1 (48 bytes BE; sign bit on the top byte)."""
+    p_mod = 0x1A0111EA397FE69A4B1BA7B6434BACD764774B84F38512BF6730D2A0F6B0F6241EABFFFEB153FFFFB9FEFFFFFFFFAAAB
+    bx = bytearray(p.x.to_bytes(48, "big"))
+    flag = 0x80
+    if 2 * p.y > p_mod:
+        flag |= 0x20
+    bx[0] |= flag
+    return bytes(bx)
+
+
+def _uncompressed_g2_bls(p) -> bytes:
+    """BLS12-381 uncompressed G2 (192 bytes BE: x0 || x1 || y0 || y1)."""
+    return (
+        p.x[0].to_bytes(48, "big")
+        + p.x[1].to_bytes(48, "big")
+        + p.y[0].to_bytes(48, "big")
+        + p.y[1].to_bytes(48, "big")
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "contract_info",
+    [
+        {
+            "contract_project": SmartContractProject(
+                smart_contract_folder=CONTRACTS_PATH / "bls_verifier"
+            )
+        },
+    ],
+)
+async def test_bls_verifier_contract(account_devnet: BaseAccount, contract_info: dict):
+    """End-to-end: declare + deploy the reference BLS verifier, then
+    invoke `verify_bls_signature` with calldata produced by
+    `garaga_rs.bls_calldata_builder` on a deterministic SK + message
+    pair. Mirrors `test_drand_contract`'s flow."""
+    from garaga import garaga_rs
+    from garaga.curves import CurveID
+    from garaga.points import G2Point as PyG2Point
+    from garaga.signature import hash_to_curve
+
+    account = account_devnet
+    contract_project: SmartContractProject = contract_info["contract_project"]
+
+    print(f"ACCOUNT {hex(account.address)}, NONCE {await account.get_nonce()}")
+
+    bls_class_hash, bls_abi = await contract_project.declare_class_hash(account)
+    print(f"Declared bls_verifier class hash: {hex(bls_class_hash)}")
+
+    precomputed_address = compute_address(
+        class_hash=bls_class_hash,
+        constructor_calldata=[],
+        salt=pedersen_hash(to_int(account.address), 1),
+        deployer_address=DEPLOYER_ADDRESS,
+    )
+
+    try_contract = await get_contract_if_exists(account, precomputed_address)
+    if try_contract is None:
+        deploy_result = await Contract.deploy_contract_v3(
+            account=account,
+            class_hash=bls_class_hash,
+            abi=bls_abi,
+            deployer_address=DEPLOYER_ADDRESS,
+            auto_estimate=True,
+            salt=1,
+            cairo_version=1,
+        )
+        await deploy_result.wait_for_acceptance()
+        contract = deploy_result.deployed_contract
+    else:
+        print(f"Contract already deployed at {hex(precomputed_address)}")
+        contract = try_contract
+
+    print(f"Deployed contract: {contract.functions}")
+
+    # Deterministic test vector pinned to the Rust unit test in
+    # tools/garaga_rs/src/calldata/bls_calldata.rs and to the
+    # downstream Shhh V8 fixture.
+    sk = 0x12345678
+    message_hash = (
+        0x05BCD634CE46C7234BD7A4B0959C3C5EDEED7F569DCFB7B33E23D7E2197A2A2F
+    )
+
+    g2_gen = PyG2Point.get_nG(CurveID.BLS12_381, 1)
+    pubkey = g2_gen.scalar_mul(sk)
+    msg_bytes = message_hash.to_bytes(32, "big")
+    msg_pt = hash_to_curve(msg_bytes, CurveID.BLS12_381, "sha256")
+    sig = msg_pt.scalar_mul(sk)
+
+    rust_inputs = [
+        message_hash,
+        int.from_bytes(_compress_g1_bls(sig), "big"),
+        int.from_bytes(_uncompressed_g2_bls(pubkey), "big"),
+    ]
+    full_calldata = garaga_rs.bls_calldata_builder(rust_inputs)
+    print(f"bls_calldata_builder emitted {len(full_calldata)} felts")
+
+    # Drop the size prefix — the contract function takes a Span and
+    # the transport layer prepends the length on its own.
+    body = full_calldata[1:]
+
+    # Pubkey passed as a separate G2Point argument (so the same
+    # verifier class authenticates any signer).
+    pubkey_struct = {
+        "x0": pubkey.x[0],
+        "x1": pubkey.x[1],
+        "y0": pubkey.y[0],
+        "y1": pubkey.y[1],
+    }
+
+    function_call: ContractFunction = find_item_from_key_patterns(
+        contract.functions, ["verify_bls_signature"]
+    )
+
+    invoke_calldata = [message_hash] + [
+        pubkey.x[0],
+        pubkey.x[1],
+        pubkey.y[0],
+        pubkey.y[1],
+    ] + [len(body)] + body
+    prepare_invoke = PreparedFunctionInvokeV3(
+        to_addr=function_call.contract_data.address,
+        calldata=invoke_calldata,
+        selector=function_call.get_selector(function_call.name),
+        _contract_data=function_call.contract_data,
+        _client=function_call.client,
+        _account=function_call.account,
+        _payload_transformer=function_call._payload_transformer,
+        resource_bounds=None,
+    )
+
+    invoke_result: InvokeResult = await prepare_invoke.invoke(auto_estimate=True)
+    await invoke_result.wait_for_acceptance()
+    print(f"Invoke status: {invoke_result.status}")
+
+    # Quiet sanity check: a simple call (no transaction) returning the
+    # bool from the same inputs should be Ok=true. The transaction
+    # invocation above already proves the contract didn't revert; this
+    # asserts the boolean return value matches the verification truth.
+    call_result = await contract.functions["verify_bls_signature"].call(
+        message_hash, pubkey_struct, body
+    )
+    assert call_result == (True,) or call_result == True, (
+        f"verify returned {call_result!r}, expected True"
+    )

--- a/tests/hydra/test_bls_calldata.py
+++ b/tests/hydra/test_bls_calldata.py
@@ -1,0 +1,137 @@
+"""
+Rust ↔ Python parity test for `garaga_rs.bls_calldata_builder`.
+
+Mirrors the convention used by every other calldata builder in
+Garaga (`use_rust=True/False` round-trip): the new Rust builder must
+emit the same `Vec<BigUint>` byte-for-byte as a Python reconstruction
+that wires together the existing primitives
+(`build_hash_to_curve_hint` + `precompute_lines` + `MPCheckCalldataBuilder`).
+
+Pinned vector matches `tools/garaga_rs/src/calldata/bls_calldata.rs`'s
+`test_bls_calldata_builder_known_fixture` so the Rust unit test, the
+Python parity test, and the downstream Shhh V8 fixture all agree.
+"""
+
+import pytest
+
+from garaga import garaga_rs
+import garaga.hints.io as io
+from garaga.curves import CurveID
+from garaga.points import G1G2Pair, G2Point
+from garaga.signature import hash_to_curve
+from garaga.starknet.tests_and_calldata_generators.map_to_curve import (
+    build_hash_to_curve_hint,
+)
+from garaga.starknet.tests_and_calldata_generators.mpcheck import (
+    MPCheckCalldataBuilder,
+)
+from garaga.precompiled_circuits.multi_miller_loop import precompute_lines
+
+
+# Deterministic vector pinned across Rust + Python + Shhh V8 fixture.
+SK = 0x12345678
+MESSAGE_HASH = 0x05BCD634CE46C7234BD7A4B0959C3C5EDEED7F569DCFB7B33E23D7E2197A2A2F
+
+
+def _build_python_calldata() -> list[int]:
+    """Reconstruct the calldata in pure Python so we can compare to the
+    Rust output element-wise."""
+    g2_gen = G2Point.get_nG(CurveID.BLS12_381, 1)
+    pubkey = g2_gen.scalar_mul(SK)
+    msg_bytes = MESSAGE_HASH.to_bytes(32, "big")
+    msg_pt = hash_to_curve(msg_bytes, CurveID.BLS12_381, "sha256")
+    sig = msg_pt.scalar_mul(SK)
+    neg_pubkey = -pubkey
+
+    h2c_hint = build_hash_to_curve_hint(msg_bytes).to_calldata()
+    lines = precompute_lines([g2_gen, neg_pubkey])
+
+    pairs = [
+        G1G2Pair(p=sig, q=g2_gen, curve_id=CurveID.BLS12_381),
+        G1G2Pair(p=msg_pt, q=neg_pubkey, curve_id=CurveID.BLS12_381),
+    ]
+    mpc_data = MPCheckCalldataBuilder(
+        curve_id=CurveID.BLS12_381,
+        pairs=pairs,
+        n_fixed_g2=2,
+        public_pair=None,
+    ).serialize_to_calldata(use_rust=True)
+
+    body: list[int] = []
+    body.extend(io.bigint_split(sig.x))
+    body.extend(io.bigint_split(sig.y))
+    body.extend(h2c_hint)
+    body.append(len(lines) // 4)
+    for pyfelt in lines:
+        body.extend(io.bigint_split(pyfelt.value))
+    body.extend(mpc_data)
+
+    return [len(body)] + body
+
+
+def _compress_g1(p) -> bytes:
+    """BLS12-381 compressed G1 (48 bytes BE, sign bit on the top byte)."""
+    p_mod = 0x1A0111EA397FE69A4B1BA7B6434BACD764774B84F38512BF6730D2A0F6B0F6241EABFFFEB153FFFFB9FEFFFFFFFFAAAB
+    bx = bytearray(p.x.to_bytes(48, "big"))
+    flag = 0x80
+    if 2 * p.y > p_mod:
+        flag |= 0x20
+    bx[0] |= flag
+    return bytes(bx)
+
+
+def _uncompressed_g2(p) -> bytes:
+    """BLS12-381 uncompressed G2 (192 bytes BE: x0 || x1 || y0 || y1)."""
+    return (
+        p.x[0].to_bytes(48, "big")
+        + p.x[1].to_bytes(48, "big")
+        + p.y[0].to_bytes(48, "big")
+        + p.y[1].to_bytes(48, "big")
+    )
+
+
+def test_bls_calldata_builder_rust_python_parity():
+    """End-to-end: Rust output ≡ Python output, byte-for-byte."""
+    g2_gen = G2Point.get_nG(CurveID.BLS12_381, 1)
+    pubkey = g2_gen.scalar_mul(SK)
+    msg_bytes = MESSAGE_HASH.to_bytes(32, "big")
+    msg_pt = hash_to_curve(msg_bytes, CurveID.BLS12_381, "sha256")
+    sig = msg_pt.scalar_mul(SK)
+
+    rust_input = [
+        MESSAGE_HASH,
+        int.from_bytes(_compress_g1(sig), "big"),
+        int.from_bytes(_uncompressed_g2(pubkey), "big"),
+    ]
+    cd_rust = garaga_rs.bls_calldata_builder(rust_input)
+    cd_python = _build_python_calldata()
+
+    assert len(cd_rust) == len(cd_python), (
+        f"length mismatch: rust={len(cd_rust)} python={len(cd_python)}"
+    )
+    assert cd_rust == cd_python, "Rust ↔ Python calldata mismatch"
+
+
+def test_bls_calldata_builder_length_matches_fixture():
+    """Match the Shhh V8 fixture's expected envelope length."""
+    g2_gen = G2Point.get_nG(CurveID.BLS12_381, 1)
+    pubkey = g2_gen.scalar_mul(SK)
+    msg_bytes = MESSAGE_HASH.to_bytes(32, "big")
+    msg_pt = hash_to_curve(msg_bytes, CurveID.BLS12_381, "sha256")
+    sig = msg_pt.scalar_mul(SK)
+
+    cd = garaga_rs.bls_calldata_builder(
+        [
+            MESSAGE_HASH,
+            int.from_bytes(_compress_g1(sig), "big"),
+            int.from_bytes(_uncompressed_g2(pubkey), "big"),
+        ]
+    )
+    # 1 (size) + 8 (sig_g1) + 12 (h2c_hint) + 1 (lines_len)
+    # + 2176 (lines) + 2079 (mpcheck_hint) = 4277.
+    assert len(cd) == 4277
+
+
+def test_bls_calldata_builder_rejects_wrong_arity():
+    with pytest.raises(ValueError):
+        garaga_rs.bls_calldata_builder([0])

--- a/tools/garaga_rs/src/calldata/bls_calldata.rs
+++ b/tools/garaga_rs/src/calldata/bls_calldata.rs
@@ -1,0 +1,393 @@
+//! Generic BLS12-381 (min-sig-size, drand DST) calldata builder.
+//!
+//! Mirrors `drand_calldata.rs` but lifts the drand-specific gates:
+//!
+//!   - the message digest is supplied directly (any 32-byte BE digest),
+//!     not derived from a drand round number;
+//!   - the G2 public key is supplied per call (BLS-compressed 96 bytes),
+//!     not resolved from `DrandNetwork::Quicknet`;
+//!   - the precomputed Miller-loop lines for the two G2 points
+//!     (`G2_GEN` and `-pubkey`) are emitted into the calldata so the
+//!     consumer contract does not need them as constants.
+//!
+//! Ciphersuite: `BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_+`
+//! (drand-quicknet, the only ciphersuite currently exposed by
+//! `garaga::apps::drand::hash_to_curve_bls12_381`).
+//!
+//! Output shape (matches the Shhh V8 verifier's expected envelope and
+//! the standard 2P_2F BLS verification calldata layout):
+//!
+//!   1. size:           u32 (1 felt)
+//!   2. signature_g1:   G1Point Serde (8 felts)
+//!   3. h2c_hint:       HashToCurveHint Serde (12 felts)
+//!   4. lines_len:      u32 (1 felt, = 136 for BLS12-381 2P_2F)
+//!   5. lines:          [G2Line<u384>; 136] (2176 felts)
+//!   6. mpcheck_hint:   MPCheckHintBLS12_381 (~2079 felts)
+//!
+//! Total on the happy path: ~4277 felts including the size prefix.
+
+use crate::algebra::extf_mul::from_e2;
+use crate::algebra::g1g2pair::G1G2Pair;
+use crate::algebra::g1point::G1Point;
+use crate::algebra::g2point::G2Point;
+use crate::calldata::drand_calldata::{
+    build_hash_to_curve_hint, deserialize_bls_point, hash_to_curve, CurvePoint,
+};
+use crate::calldata::mpc_calldata;
+use crate::definitions::{BLS12381PrimeField, CurveID, CurveParamsProvider, FieldElement};
+use crate::io::field_element_to_u384_limbs;
+use lambdaworks_math::elliptic_curve::short_weierstrass::curves::bls12_381::field_extension::Degree12ExtensionField as BLS12381Degree12ExtensionField;
+use lambdaworks_math::elliptic_curve::short_weierstrass::curves::bls12_381::field_extension::Degree2ExtensionField as BLS12381Degree2ExtensionField;
+use lambdaworks_math::elliptic_curve::short_weierstrass::curves::bls12_381::field_extension::Degree6ExtensionField as BLS12381Degree6ExtensionField;
+use num_bigint::BigUint;
+
+type F = BLS12381PrimeField;
+type E2 = BLS12381Degree2ExtensionField;
+
+/// Build the on-chain calldata for a BLS12-381 min-sig-size signature
+/// verification.
+///
+/// `values` MUST contain exactly three big-endian unsigned integers:
+///
+///   - `values[0]` — 32-byte big-endian message digest (left-padded
+///     if shorter).
+///   - `values[1]` — 48-byte BLS-compressed OR 96-byte uncompressed
+///     G1 signature.
+///   - `values[2]` — 192-byte uncompressed G2 public key
+///     `(x0 || x1 || y0 || y1)` (big-endian, 48 bytes each).
+///     Garaga's current `deserialize_bls_point` does not yet decode
+///     compressed G2 points; callers should send the uncompressed
+///     form. A follow-up PR can lift this restriction once
+///     compressed-G2 decoding lands upstream.
+pub fn bls_calldata_builder(values: &[BigUint]) -> Result<Vec<BigUint>, String> {
+    if values.len() != 3 {
+        return Err(format!("Invalid data array length: {}", values.len()));
+    }
+
+    // ---------- 1. parse message digest (left-pad to 32 bytes BE) ----------
+    let message: [u8; 32] = {
+        let bytes = values[0].to_bytes_be();
+        if bytes.len() > 32 {
+            return Err(format!(
+                "message_hash must fit in 32 bytes, got {}",
+                bytes.len()
+            ));
+        }
+        let mut padded = [0u8; 32];
+        let len = bytes.len();
+        padded[32 - len..].copy_from_slice(&bytes);
+        padded
+    };
+
+    // ---------- 2. parse G1 signature (compressed, 48 bytes) ----------
+    let signature_pt: G1Point<F> = {
+        let bytes = values[1].to_bytes_be();
+        if bytes.len() > 48 {
+            return Err(format!(
+                "signature must fit in 48 bytes, got {}",
+                bytes.len()
+            ));
+        }
+        let mut padded = [0u8; 48];
+        let len = bytes.len();
+        padded[48 - len..].copy_from_slice(&bytes);
+        match deserialize_bls_point(&padded)? {
+            CurvePoint::G1Point(p) => p,
+            CurvePoint::G2Point(_) => {
+                return Err("expected G1 signature, got G2 point".to_string());
+            }
+        }
+    };
+
+    // ---------- 3. parse G2 public key (uncompressed, 192 bytes) ----------
+    let pubkey_pt: G2Point<F, E2> = {
+        let bytes = values[2].to_bytes_be();
+        if bytes.len() > 192 {
+            return Err(format!(
+                "pubkey must fit in 192 uncompressed bytes, got {}",
+                bytes.len()
+            ));
+        }
+        let mut padded = [0u8; 192];
+        let len = bytes.len();
+        padded[192 - len..].copy_from_slice(&bytes);
+        match deserialize_bls_point(&padded)? {
+            CurvePoint::G2Point(p) => p,
+            CurvePoint::G1Point(_) => {
+                return Err("expected G2 pubkey, got G1 point".to_string());
+            }
+        }
+    };
+
+    // ---------- 4. compute H(m) ----------
+    let msg_pt: G1Point<F> = hash_to_curve::<F>(message, "sha256")?;
+
+    // ---------- 5. build h2c_hint calldata ----------
+    let h2c_hint = build_hash_to_curve_hint(message)?.to_calldata()?;
+
+    // ---------- 6. precompute Miller-loop lines for [G2_GEN, -pubkey] ----------
+    let g2_gen = G2Point::<F, E2>::generator();
+    let neg_pubkey = pubkey_pt.neg();
+    let lines = precompute_lines_bls12_381(&[g2_gen.clone(), neg_pubkey.clone()]);
+
+    // ---------- 7. build mpcheck_hint calldata ----------
+    let pairs = [
+        G1G2Pair::new(signature_pt.clone(), g2_gen),
+        G1G2Pair::new(msg_pt, neg_pubkey),
+    ];
+    let mpc_data = mpc_calldata::calldata_builder::<
+        false,
+        F,
+        E2,
+        BLS12381Degree6ExtensionField,
+        BLS12381Degree12ExtensionField,
+    >(&pairs, 2, &None)?;
+
+    // ---------- 8. assemble calldata ----------
+    // Body = signature_g1 (8) + h2c_hint (12) + lines_len (1) + lines + mpcheck_hint
+    let lines_felts: Vec<BigUint> = lines
+        .iter()
+        .flat_map(|fe| {
+            field_element_to_u384_limbs(fe)
+                .into_iter()
+                .map(BigUint::from)
+        })
+        .collect();
+    let n_lines = lines.len() / 4;
+
+    let body_len = 4 + 4 + h2c_hint.len() + 1 + lines_felts.len() + mpc_data.len();
+    let mut call_data: Vec<BigUint> = Vec::with_capacity(1 + body_len);
+    call_data.push(BigUint::from(body_len));
+    call_data.extend(
+        field_element_to_u384_limbs(&signature_pt.x)
+            .into_iter()
+            .map(BigUint::from),
+    );
+    call_data.extend(
+        field_element_to_u384_limbs(&signature_pt.y)
+            .into_iter()
+            .map(BigUint::from),
+    );
+    call_data.extend(h2c_hint);
+    call_data.push(BigUint::from(n_lines));
+    call_data.extend(lines_felts);
+    call_data.extend(mpc_data);
+
+    debug_assert_eq!(call_data.len(), 1 + body_len);
+    Ok(call_data)
+}
+
+// ----------------------------------------------------------------
+//  Miller-loop line precomputation (port of Python
+//  `hydra/garaga/precompiled_circuits/multi_miller_loop.py:precompute_lines`).
+//
+//  For every step in the BLS12-381 ate Miller loop counter we emit
+//  the raw line coefficients (r0_e2, r1_e2) in Fp2, flattened as
+//  four FieldElement<Fp> entries each. The 64-bit BLS loop counter
+//  has 67 nonzero contributions (initial bit + 64 doubles + 4
+//  double-and-add steps) → 136 total lines for n_pairs=2.
+// ----------------------------------------------------------------
+
+/// Precompute Miller-loop lines for a list of G2 points on BLS12-381.
+/// Returns a flat `Vec<FieldElement<F>>` where every group of 4
+/// elements represents one G2Line in the Cairo verifier:
+/// `[r0a0, r0a1, r1a0, r1a1]` (Fp2 → 2 felts each, 2 lines per step).
+pub fn precompute_lines_bls12_381(qs: &[G2Point<F, E2>]) -> Vec<FieldElement<F>> {
+    if qs.is_empty() {
+        return vec![];
+    }
+    let curve_params = F::get_curve_params();
+    debug_assert_eq!(curve_params.curve_id, CurveID::BLS12_381);
+    let loop_counter = curve_params.loop_counter;
+    let start_index = loop_counter.len() - 2;
+    let n_pairs = qs.len();
+
+    let mut points: Vec<G2Point<F, E2>> = Vec::with_capacity(n_pairs);
+    let mut out: Vec<FieldElement<F>> = Vec::new();
+
+    // --- initial bit ---
+    if loop_counter[start_index] == 1 {
+        for q in qs.iter() {
+            let (t, l1, l2) = step_triple(q);
+            push_line(&mut out, &l1);
+            push_line(&mut out, &l2);
+            points.push(t);
+        }
+    } else if loop_counter[start_index] == 0 {
+        for q in qs.iter() {
+            let (t, l1) = step_double(q);
+            push_line(&mut out, &l1);
+            points.push(t);
+        }
+    } else {
+        panic!("Unsupported initial loop-counter bit for BLS12-381");
+    }
+
+    // --- main loop, MSB-1 → LSB ---
+    for i in (0..start_index).rev() {
+        let bit = loop_counter[i];
+        let mut new_points: Vec<G2Point<F, E2>> = Vec::with_capacity(n_pairs);
+        if bit == 0 {
+            for p in points.iter() {
+                let (t, l1) = step_double(p);
+                push_line(&mut out, &l1);
+                new_points.push(t);
+            }
+        } else if bit == 1 || bit == -1 {
+            for (k, p) in points.iter().enumerate() {
+                let q_select = if bit == 1 { qs[k].clone() } else { qs[k].neg() };
+                let (t, l1, l2) = step_double_and_add(p, &q_select);
+                push_line(&mut out, &l1);
+                push_line(&mut out, &l2);
+                new_points.push(t);
+            }
+        } else {
+            panic!("Unsupported loop-counter bit for BLS12-381");
+        }
+        points = new_points;
+    }
+
+    // BLS12-381 has no finalize step (only BN254 does), so we're done.
+    out
+}
+
+/// Append a single Fp2-pair line (lineR0, lineR1) to the output as 4
+/// FieldElement<F> entries: [r0a0, r0a1, r1a0, r1a1].
+fn push_line(out: &mut Vec<FieldElement<F>>, line: &(FieldElement<E2>, FieldElement<E2>)) {
+    let [r0a0, r0a1] = from_e2::<F, E2>(line.0.clone());
+    let [r1a0, r1a1] = from_e2::<F, E2>(line.1.clone());
+    out.push(r0a0);
+    out.push(r0a1);
+    out.push(r1a0);
+    out.push(r1a1);
+}
+
+/// Emit the new T = 2·Q point and the line `(λ, λ·Q.x − Q.y)` from a
+/// single Miller-loop doubling step. Mirrors Python's `_double`.
+fn step_double(q: &G2Point<F, E2>) -> (G2Point<F, E2>, (FieldElement<E2>, FieldElement<E2>)) {
+    let lambda: FieldElement<E2> = G2Point::compute_doubling_slope(q);
+    let xr = &(&lambda * &lambda) - &(&q.x + &q.x);
+    let yr = &(&lambda * &(&q.x - &xr)) - &q.y;
+    let t = G2Point::new_unchecked(xr, yr);
+    let line_r0 = lambda.clone();
+    let line_r1 = &(&lambda * &q.x) - &q.y;
+    (t, (line_r0, line_r1))
+}
+
+/// Emit T = 2·Qa + Qb and two lines from a single double-and-add step.
+/// Mirrors Python's `_double_and_add`.
+fn step_double_and_add(
+    qa: &G2Point<F, E2>,
+    qb: &G2Point<F, E2>,
+) -> (
+    G2Point<F, E2>,
+    (FieldElement<E2>, FieldElement<E2>),
+    (FieldElement<E2>, FieldElement<E2>),
+) {
+    let lambda1 = G2Point::compute_adding_slope(qa, qb);
+    let x3 = &(&lambda1 * &lambda1) - &(&qa.x + &qb.x);
+    let line1_r0 = lambda1.clone();
+    let line1_r1 = &(&lambda1 * &qa.x) - &qa.y;
+    let num = &qa.y + &qa.y;
+    let den = &x3 - &qa.x;
+    let lambda2 = -&(&lambda1 + &(&num / &den).unwrap());
+    let x4 = &(&(&lambda2 * &lambda2) - &qa.x) - &x3;
+    let y4 = &(&lambda2 * &(&qa.x - &x4)) - &qa.y;
+    let t = G2Point::new_unchecked(x4, y4);
+    let line2_r0 = lambda2.clone();
+    let line2_r1 = &(&lambda2 * &qa.x) - &qa.y;
+    (t, (line1_r0, line1_r1), (line2_r0, line2_r1))
+}
+
+/// Emit T = 3·Q and two lines from a single tripling step. Mirrors
+/// Python's `_triple` — first a doubling-slope to derive an
+/// intermediate point and slope, then an addition step relative to Q.
+fn step_triple(
+    q: &G2Point<F, E2>,
+) -> (
+    G2Point<F, E2>,
+    (FieldElement<E2>, FieldElement<E2>),
+    (FieldElement<E2>, FieldElement<E2>),
+) {
+    let lambda1 = G2Point::compute_doubling_slope(q);
+    let x_mid = &(&lambda1 * &lambda1) - &(&q.x + &q.x);
+    let line1_r0 = lambda1.clone();
+    let line1_r1 = &(&lambda1 * &q.x) - &q.y;
+    let num = &q.y + &q.y;
+    let den = &x_mid - &q.x;
+    let lambda2 = -&(&lambda1 + &(&num / &den).unwrap());
+    let x_final = &(&(&lambda2 * &lambda2) - &q.x) - &x_mid;
+    let y_final = &(&lambda2 * &(&q.x - &x_final)) - &q.y;
+    let t = G2Point::new_unchecked(x_final, y_final);
+    let line2_r0 = lambda2.clone();
+    let line2_r1 = &(&lambda2 * &q.x) - &q.y;
+    (t, (line1_r0, line1_r1), (line2_r0, line2_r1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// End-to-end happy-path against the deterministic fixture pinned
+    /// at `haycarlitos/shhh-wallet-cairo:scripts/py/gen_bls_fixture.py`:
+    ///   sk           = 0x12345678
+    ///   message_hash = 0x05bcd634…2197a2a2f
+    ///   pubkey_g2    = sk · G2_GEN          (compressed below)
+    ///   signature_g1 = sk · H(message_hash) (compressed below)
+    /// On this input `bls_calldata_builder` MUST emit exactly 4277
+    /// felts: 1 (size) + 8 (sig_g1) + 12 (h2c_hint) + 1 (lines_len)
+    /// + 2176 (lines) + 2079 (mpcheck_hint) = 4277.
+    #[test]
+    fn test_bls_calldata_builder_known_fixture() {
+        let message_hash = BigUint::parse_bytes(
+            b"05bcd634ce46c7234bd7a4b0959c3c5edeed7f569dcfb7b33e23d7e2197a2a2f",
+            16,
+        )
+        .unwrap();
+        let signature_compressed = BigUint::parse_bytes(
+            b"80ffac3b39757a00a67e77515c2ddd3e48d317dda4578eb2cab7bfbbfa657093c5277edefa2c595ff1c7709a37b3d4a1",
+            16,
+        )
+        .unwrap();
+        // Uncompressed G2: x0 || x1 || y0 || y1 (48 bytes each).
+        let pubkey_uncompressed = BigUint::parse_bytes(
+            b"13dec97a5c18cf35174115e4743fb04043ee71f7d7d5e43033c2dfa04be7c1d60a73315a3cd48a9839c980732b4934b10f40cb7f4e60ef34d19a36bd662b2434914fdb764559e98f4058d0160f4b56c99284598c03363926be3fac1180c95f650d0567ebb42929a41c47be7b6a6162a2a68f723aa049ab7558ace3838346386680bd788384703c673977e4e88e86e76a1939db2a9fe74ef4e99ba3b3b075ff46d18f8c27c41bf07a7704b984535494b9e8b804807172aa1b85caab6973ca2e15",
+            16,
+        )
+        .unwrap();
+
+        let calldata =
+            bls_calldata_builder(&[message_hash, signature_compressed, pubkey_uncompressed])
+                .expect("builder failed on known fixture");
+
+        // 1 (size) + 8 (sig) + 12 (h2c_hint) + 1 (lines_len) + 2176 (lines) + 2079 (mpcheck_hint).
+        assert_eq!(
+            calldata.len(),
+            4277,
+            "calldata length must match the Shhh V8 verifier envelope"
+        );
+
+        // size prefix self-check
+        let body_len = &calldata[0];
+        assert_eq!(body_len, &BigUint::from(4276u32));
+    }
+
+    /// Reject obviously-malformed inputs without panicking.
+    #[test]
+    fn test_bls_calldata_builder_rejects_wrong_arity() {
+        let r = bls_calldata_builder(&[BigUint::from(0u64)]);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn test_precompute_lines_count_matches_python() {
+        // For BLS12-381 with 2 G2 points the Cairo verifier consumes
+        // exactly 136 G2Line<u384> records (= 544 FieldElement<F> in
+        // raw form). Python's hydra.precompute_lines produces the
+        // same count; this test pins Rust's output length to 544.
+        let g = G2Point::<F, E2>::generator();
+        let g_neg = g.neg();
+        let lines = precompute_lines_bls12_381(&[g, g_neg]);
+        assert_eq!(lines.len(), 544, "expected 544 felts (136 lines × 4)");
+    }
+}

--- a/tools/garaga_rs/src/calldata/drand_calldata.rs
+++ b/tools/garaga_rs/src/calldata/drand_calldata.rs
@@ -510,7 +510,7 @@ pub struct HashToCurveHint {
 }
 
 impl HashToCurveHint {
-    fn to_calldata(&self) -> Result<Vec<BigUint>, String> {
+    pub fn to_calldata(&self) -> Result<Vec<BigUint>, String> {
         let mut call_data = vec![];
         call_data.extend(self.f0_hint.to_calldata());
         call_data.extend(self.f1_hint.to_calldata());
@@ -518,7 +518,7 @@ impl HashToCurveHint {
     }
 }
 
-fn build_hash_to_curve_hint(message: [u8; 32]) -> Result<HashToCurveHint, String> {
+pub fn build_hash_to_curve_hint(message: [u8; 32]) -> Result<HashToCurveHint, String> {
     let [felt0, felt1] = hash_to_field::<BLS12381PrimeField>(message, 2, "sha256")?
         .try_into()
         .unwrap();

--- a/tools/garaga_rs/src/calldata/mod.rs
+++ b/tools/garaga_rs/src/calldata/mod.rs
@@ -1,3 +1,4 @@
+pub mod bls_calldata;
 pub mod drand_calldata;
 pub mod drand_tlock_calldata;
 pub mod full_proof_with_hints {

--- a/tools/garaga_rs/src/python_bindings/bls_calldata.rs
+++ b/tools/garaga_rs/src/python_bindings/bls_calldata.rs
@@ -1,0 +1,13 @@
+use super::*;
+
+#[pyfunction]
+pub fn bls_calldata_builder(py: Python, py_list1: &Bound<'_, PyList>) -> PyResult<Py<PyAny>> {
+    let values1 = py_list1
+        .into_iter()
+        .map(|x| x.extract())
+        .collect::<Result<Vec<BigUint>, _>>()?;
+    let result = crate::calldata::bls_calldata::bls_calldata_builder(&values1)
+        .map_err(PyErr::new::<pyo3::exceptions::PyValueError, _>)?;
+    let py_list = PyList::new(py, result);
+    Ok(py_list?.into())
+}

--- a/tools/garaga_rs/src/python_bindings/mod.rs
+++ b/tools/garaga_rs/src/python_bindings/mod.rs
@@ -1,3 +1,4 @@
+pub mod bls_calldata;
 pub mod drand_calldata;
 pub mod ecip;
 pub mod extf_mul;
@@ -79,6 +80,7 @@ fn garaga_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     )?)?;
     m.add_function(wrap_pyfunction!(poseidon_hash_bn254, m)?)?;
     m.add_function(wrap_pyfunction!(pairing::final_exp, m)?)?;
+    m.add_function(wrap_pyfunction!(bls_calldata::bls_calldata_builder, m)?)?;
     m.add_function(wrap_pyfunction!(drand_calldata::drand_calldata_builder, m)?)?;
     m.add_function(wrap_pyfunction!(
         drand_calldata::drand_tlock_encrypt_calldata_builder,

--- a/tools/garaga_rs/src/wasm_bindings.rs
+++ b/tools/garaga_rs/src/wasm_bindings.rs
@@ -15,6 +15,21 @@ use num_traits::Num;
 use wasm_bindgen::prelude::*; // Import the Num trait
 
 #[wasm_bindgen]
+pub fn bls_calldata_builder(values: Vec<JsValue>) -> Result<Vec<JsValue>, JsValue> {
+    let values: Vec<BigUint> = values
+        .into_iter()
+        .map(jsvalue_to_biguint)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let result = crate::calldata::bls_calldata::bls_calldata_builder(&values)
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+    let result: Vec<BigUint> = result;
+
+    Ok(result.into_iter().map(biguint_to_jsvalue).collect())
+}
+
+#[wasm_bindgen]
 pub fn drand_calldata_builder(values: Vec<JsValue>) -> Result<Vec<JsValue>, JsValue> {
     let values: Vec<BigUint> = values
         .into_iter()


### PR DESCRIPTION
<!-- Draft PR opened to share work-in-progress on issue #518. -->

# Pull Request type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

The npm bundle's only BLS-related calldata builders are drand-locked:

- `drand_calldata_builder(values)` accepts only `[round_number, randomness, signature]` and resolves the chain pubkey from the hardcoded `DrandNetwork::Quicknet` constant.
- `getDrandCallData({ round, randomness, signature })` is the JS wrapper over the same.
- `fetchDrandRandomness` / `fetchAndGetDrandCallData` are drand-network HTTP helpers.

There is no JS-facing entry point for "given an arbitrary 32-byte message digest, an arbitrary G2 pubkey, and a G1 signature, build the verification calldata that `garaga::apps::drand::hash_to_curve_bls12_381` + `garaga::pairing_check::multi_pairing_check_bls12_381_2P_2F` consume." The Python `garaga` package already ships every primitive (`build_hash_to_curve_hint`, `MPCheckCalldataBuilder`), and the Rust `drand_calldata.rs` does the heavy lifting once you skip the round/chain-pubkey gates.

Issue Number: #518

# What is the new behavior?

Adds a generic `bls_calldata_builder` to the Rust core, mirroring the `drand_calldata_builder` shape (flat `&[BigUint]` in, `Vec<BigUint>` out) so it slots into the existing wasm + PyO3 binding pattern with zero special-casing.

- New file `tools/garaga_rs/src/calldata/bls_calldata.rs`:
  - `pub fn bls_calldata_builder(values: &[BigUint]) -> Result<Vec<BigUint>, String>` accepts `[message_hash, sig_g1, pubkey_g2_uncompressed]` and emits the full calldata: `size | sig_g1(8) | h2c_hint(12) | lines_len(1) | lines(2176) | mpcheck_hint(~2079)` = ~4277 felts on the happy path.
  - `pub fn precompute_lines_bls12_381(qs: &[G2Point])` ports `hydra/garaga/precompiled_circuits/multi_miller_loop.py:precompute_lines` to Rust so the calldata is self-contained.
- WASM binding next to `drand_calldata_builder` in `wasm_bindings.rs`.
- PyO3 binding in `python_bindings/bls_calldata.rs` + `python_bindings/mod.rs`.
- `drand_calldata.rs`: `build_hash_to_curve_hint` and `HashToCurveHint::to_calldata` made `pub` so the new module can reuse them. No behaviour change to `drand_calldata_builder`.

DST is fixed to `BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_+` (drand-quicknet ciphersuite — the only one Garaga's `hash_to_curve_bls12_381` exposes).

Tests under `cfg(test)` in `bls_calldata.rs`:

- `test_precompute_lines_count_matches_python` — asserts the Rust port emits 544 felts (= 136 G2Lines × 4) for `n_pairs=2`, matching Python's flat output.
- `test_bls_calldata_builder_known_fixture` — end-to-end on a pinned deterministic vector (`sk=0x12345678`, `message_hash=0x05bcd…2a2f` matching the Shhh V8 fixture). Asserts full calldata = 4277 felts.
- `test_bls_calldata_builder_rejects_wrong_arity` — graceful error.

Verification:

- `cargo test -p garaga_rs --lib` — 57 passed (54 prior + 3 new), 0 failed.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets` — no new warnings on the added file.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

# Other information

**Concrete downstream consumer**: Shhh Wallet V8 ships `Bls12_381MinSigVerifier` ([haycarlitos/shhh-wallet-cairo, branch v8-robust](https://github.com/haycarlitos/shhh-wallet-cairo/tree/v8-robust), commit [`a3e1969`](https://github.com/haycarlitos/shhh-wallet-cairo/commit/a3e1969), 9/9 verifier tests passing on chain). Today it generates fixtures via a Python sidecar (`scripts/py/gen_bls_fixture.py`). Once this PR lands, the same fixtures generate from the browser through the npm bundle.

**Known limitations / follow-ups** that I left out of this PR to keep it focused:

1. **WASM regeneration** — `make wasm` requires Docker; the regenerated `tools/npm/garaga_ts/src/wasm/pkg/` artifacts are NOT included here. Happy to add them once the Rust/Python side is reviewed (or maintainer can regen on merge).
2. **Compressed G2 decoding** — `tools/garaga_rs/src/calldata/drand_calldata.rs:682` still says `unimplemented!()` for compressed G2. The new builder accepts G2 uncompressed (192 bytes); a follow-up PR can lift this once compressed-G2 support lands. The Python `deserialize_bls_point` in `hydra/garaga/drand/client.py` already implements it as a reference.
3. **TypeScript wrapper, Jest test, integration suites (Node CJS / Node ESM / Webpack / React), and starknet-devnet E2E test** — will follow in a separate PR once this Rust + Python core is reviewed.
4. **Python parity test** — the existing `MPCheckCalldataBuilder` + `build_hash_to_curve_hint` already produce the same shape; a pytest `assert calldata_py == calldata_rs` is straightforward to add. I left it out of this PR pending maintainer feedback on whether to ship it now or after item 1 is regenerated.

Pinned test vector for any maintainer who wants to reproduce locally (lives in our downstream `gen_bls_fixture.py`):

```
message_hash       = 0x05bcd634ce46c7234bd7a4b0959c3c5edeed7f569dcfb7b33e23d7e2197a2a2f
sk                 = 0x12345678
pubkey (sk·G2_GEN) = 0x13dec97a…932b4934b1 (192 bytes uncompressed)
sig (sk·H(m), 48B) = 0x80ffac3b39…7b3d4a1
expected calldata  = 4277 felts
```

Marking as draft so we can iterate on items 1–4 if you'd prefer. Happy to land everything in this PR if that's the cleaner path.
